### PR TITLE
feat(#18): cross-platform UTF-8 encoding for spawn processes

### DIFF
--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -484,18 +484,22 @@ Started: ${timestamp}
       this.logger.log(`Executing ${this.name} with prompt (length: ${prompt.length})`);
 
       return new Promise((resolve) => {
-        // Set UTF-8 encoding for Windows PowerShell to handle Korean/Unicode correctly
-        const env = { ...process.env, ...this.getEnv() };
+        // Set UTF-8 encoding to handle Korean/Unicode correctly across all platforms
+        const env: Record<string, string | undefined> = {
+          ...process.env,
+          LANG: 'en_US.UTF-8',
+          LC_ALL: 'en_US.UTF-8',
+          ...this.getEnv(),
+        };
         if (process.platform === 'win32') {
           env.PYTHONIOENCODING = 'utf-8';
-          env.LANG = 'en_US.UTF-8';
         }
-        
+
         // For Windows, use the full path to .cmd file if needed
         let executable = executablePath;
         let spawnArgs = args;
         let useShell = false;
-        
+
         if (process.platform === 'win32' && !executablePath.match(/\.(cmd|bat|ps1)$/i)) {
           // On Windows, if executable doesn't have extension, spawn needs shell
           useShell = true;
@@ -699,11 +703,15 @@ Started: ${timestamp}
       this.logger.log(`Executing ${this.name} in execute mode (length: ${prompt.length})`);
 
       return new Promise((resolve) => {
-        // Set UTF-8 encoding for Windows PowerShell to handle Korean/Unicode correctly
-        const env = { ...process.env, ...this.getEnv() };
+        // Set UTF-8 encoding to handle Korean/Unicode correctly across all platforms
+        const env: Record<string, string | undefined> = {
+          ...process.env,
+          LANG: 'en_US.UTF-8',
+          LC_ALL: 'en_US.UTF-8',
+          ...this.getEnv(),
+        };
         if (process.platform === 'win32') {
           env.PYTHONIOENCODING = 'utf-8';
-          env.LANG = 'en_US.UTF-8';
         }
 
         // For Windows, use the full path to .cmd file if needed


### PR DESCRIPTION
## Summary
- Set `LANG` and `LC_ALL` environment variables to `en_US.UTF-8` for all platforms (Linux, macOS, Windows)
- Keep Windows-specific `PYTHONIOENCODING` setting for Python compatibility
- Ensures proper handling of Korean/Unicode characters in spawn processes

## Changes
- `packages/sdk/src/core/providers/base-ai.provider.ts`
  - Added `LANG` and `LC_ALL` to default environment for all platforms
  - Moved Windows-specific settings to conditional block

## Test plan
- [x] Build SDK (`npm run build:sdk`) - passed
- [ ] Manual test with Korean characters in prompt/response
- [ ] Cross-platform testing (Linux/macOS/Windows)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)