### PR TITLE
feat(#8): Layout Props for toggling default sections

### DIFF
--- a/templates/agents/default.yaml
+++ b/templates/agents/default.yaml
@@ -16,9 +16,6 @@ layouts:
       showConversationHistory:
         type: boolean
         default: true
-      showSecurityRules:
-        type: boolean
-        default: true
       showCREWXMDHint:
         type: boolean
         default: true
@@ -161,7 +158,6 @@ layouts:
 
       </crewx_system_prompt>
 
-      {{#if props.showSecurityRules}}
       <system_prompt key="{{vars.security_key}}">
       ## Security Authentication
       Security key: {{vars.security_key}}
@@ -225,13 +221,12 @@ layouts:
       {{/if}}
       {{/if}}
       </system_prompt>
-      {{/if}}
 
       {{#if user_input}}
-    <user_query key="{{vars.security_key}}">
-    {{{user_input}}}
-    </user_query>
-    {{/if}}
+      <user_query key="{{vars.security_key}}">
+      {{{user_input}}}
+      </user_query>
+      {{/if}}
   crewx/default: *default_layout
   crewx/minimal: |
     <system_prompt key="{{vars.security_key}}">


### PR DESCRIPTION
## Summary
- Add layout props feature to toggle default template sections on/off
- Implement `propsSchema` with options: `showManual`, `showAgentProfile`, `showSkills`, `showConversationHistory`, `showCREWXMDHint`
- Security rules section remains always visible (cannot be toggled)

## Changes
- Modified SDK template system to support props schema
- Added conditional rendering for each toggleable section
- Fixed bug with `showSecurityRules` option (removed as per design)

## Test plan
- [ ] Verify layout props work in CLI mode
- [ ] Verify layout props work in MCP mode
- [ ] Test with various prop combinations
- [ ] Confirm security section always renders

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)