### PR TITLE
fix(#22): disable shouldPipeContext to fix EPIPE error

### DIFF
--- a/packages/sdk/src/core/providers/codex.provider.ts
+++ b/packages/sdk/src/core/providers/codex.provider.ts
@@ -33,11 +33,12 @@ export class CodexProvider extends BaseAIProvider {
   }
 
   /**
-   * Enable piped context for thread-based conversation continuity.
-   * Codex CLI accepts conversation history via stdin similar to other CLI providers.
+   * Codex CLI does not read from stdin, so piped context causes EPIPE error.
+   * Instead, conversation_history is already included in the rendered prompt
+   * and passed via args (since getPromptInArgs() returns true).
    */
   protected shouldPipeContext(): boolean {
-    return true;
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix EPIPE error when using `--thread` option with Codex provider
- Change `shouldPipeContext()` from `true` to `false`
- Codex CLI does not read from stdin, so piping context causes EPIPE error
- Since `getPromptInArgs()` returns `true`, the rendered prompt (including `conversation_history`) is already passed via args

## Test plan
- [x] Build passes
- [x] `crewx q "@crewx_codex_dev 안녕" --thread test` works without EPIPE error
- [x] Conversation history is remembered across thread messages

## Related
Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)