### PR TITLE
feat(#28): increase log truncation limits by 10x

### DIFF
--- a/packages/sdk/src/config/log.config.ts
+++ b/packages/sdk/src/config/log.config.ts
@@ -9,9 +9,9 @@ export interface LogConfig {
 }
 
 const DEFAULT_LOG_CONFIG: LogConfig = {
-  promptMaxLength: 10000,
-  toolResultMaxLength: 2000,
-  conversationMaxLength: 4000,
+  promptMaxLength: 100000,
+  toolResultMaxLength: 20000,
+  conversationMaxLength: 40000,
 };
 
 export function getLogConfig(env: NodeJS.ProcessEnv = process.env): LogConfig {


### PR DESCRIPTION
## Summary
- Closes #28
- Increase log truncation limits by 10x for better debugging experience

## Changes
| Config | Before | After |
|--------|--------|-------|
| `promptMaxLength` | 10,000 | 100,000 |
| `toolResultMaxLength` | 2,000 | 20,000 |
| `conversationMaxLength` | 4,000 | 40,000 |

## File Changed
- `packages/sdk/src/config/log.config.ts`

## Test
- ✅ Build passed (`npm run build`)
- ✅ No breaking changes (10x increase is backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>