### PR TITLE
fix(#31): Fix ERR_REQUIRE_ESM via slugify downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "rimraf": "^5.0.5"
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "overrides": {
+      "@sindresorhus/slugify": "1.1.2"
+    }
+  },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.44",
     "@ai-sdk/google": "^2.0.31",


### PR DESCRIPTION
## Summary

Fixes #31 - Windows ERR_REQUIRE_ESM error caused by @mastra/core requiring ESM-only @sindresorhus/slugify

## Changes

- Added pnpm.overrides section to root package.json
- Forced downgrade of @sindresorhus/slugify from 2.x (ESM only) to 1.1.2 (CJS compatible)

## Solution Approach

Instead of migrating to Vercel AI SDK (which would be a larger change), this PR uses pnpm's override feature to force a compatible version of slugify. This is a proven solution used by projects like Reactive Resume (https://github.com/AmruthPillai/Reactive-Resume/pull/2220).

## Testing

- ✅ Build succeeded: `npm run build`
- ✅ CLI works: `crewx --version` returns 0.7.7
- ✅ No ERR_REQUIRE_ESM errors

## Related

- Issue: https://github.com/sowonlabs/crewx/issues/31
- Reference solution: https://github.com/AmruthPillai/Reactive-Resume/pull/2220
- pnpm overrides docs: https://pnpm.io/package_json#pnpmoverrides