### PR TITLE
fix(#31): downgrade @sindresorhus/slugify to fix ERR_REQUIRE_ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     "rimraf": "^5.0.5"
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "overrides": {
+      "@sindresorhus/slugify": "1.1.2"
+    }
+  },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.44",
     "@ai-sdk/google": "^2.0.31",


### PR DESCRIPTION
## Fixes #31

## Problem
Windows users experiencing complete CLI failure with `ERR_REQUIRE_ESM` error. The issue is caused by `@mastra/core` (CJS build) attempting to `require()` an ESM-only package `@sindresorhus/slugify` v2.x.

## Solution
Use pnpm overrides to force downgrade `@sindresorhus/slugify` from v2.x (ESM only) to v1.1.2 (CommonJS compatible).

## Changes
- Added `pnpm.overrides` section to root `package.json`
- Forces `@sindresorhus/slugify@1.1.2` across all dependencies
- Version 1.1.2 supports CommonJS `require()` needed by `@mastra/core`

## Testing
- ✅ Build successful
- ✅ CLI runs without ERR_REQUIRE_ESM error
- ✅ `crewx --version` works correctly
- ✅ pnpm-lock.yaml confirms slugify@1.1.2 is used

## References
- Similar fix: https://github.com/AmruthPillai/Reactive-Resume/pull/2220
- pnpm overrides docs: https://pnpm.io/package_json#pnpmoverrides