### PR TITLE
feat(#53): inject CREWX environment variables

### DIFF
--- a/packages/cli/src/services/tracing.service.ts
+++ b/packages/cli/src/services/tracing.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Optional, Inject } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
@@ -107,7 +107,9 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
   private db: Database.Database | null = null;
   private dbPath: string;
 
-  constructor(options?: TracingServiceOptions) {
+  constructor(
+    @Optional() @Inject('TRACING_OPTIONS') options?: TracingServiceOptions,
+  ) {
     if (options?.dbPath) {
       this.dbPath = options.dbPath;
     } else {

--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -489,6 +489,9 @@ Started: ${timestamp}
           ...process.env,
           LANG: 'en_US.UTF-8',
           LC_ALL: 'en_US.UTF-8',
+          CREWX_TASK_ID: taskId,
+          CREWX_AGENT_ID: options.agentId || '',
+          CREWX_USER_ID: process.env.USER || process.env.USERNAME || 'unknown',
           ...this.getEnv(),
         };
         if (process.platform === 'win32') {
@@ -708,6 +711,9 @@ Started: ${timestamp}
           ...process.env,
           LANG: 'en_US.UTF-8',
           LC_ALL: 'en_US.UTF-8',
+          CREWX_TASK_ID: taskId,
+          CREWX_AGENT_ID: options.agentId || '',
+          CREWX_USER_ID: process.env.USER || process.env.USERNAME || 'unknown',
           ...this.getEnv(),
         };
         if (process.platform === 'win32') {

--- a/packages/sdk/tests/unit/providers/base-ai-env.test.ts
+++ b/packages/sdk/tests/unit/providers/base-ai-env.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BaseAIProvider } from '../../../src/core/providers/base-ai.provider';
+import * as child_process from 'child_process';
+import { EventEmitter } from 'events';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execSync: vi.fn().mockReturnValue('/bin/echo'),
+}));
+
+class TestProvider extends BaseAIProvider {
+  name = 'cli/test';
+  getCliCommand() { return 'echo'; }
+  getDefaultArgs() { return []; }
+  getExecuteArgs() { return []; }
+  getNotInstalledMessage() { return 'error'; }
+}
+
+describe('BaseAIProvider Environment Variables', () => {
+  let provider: TestProvider;
+  
+  beforeEach(() => {
+    provider = new TestProvider('test');
+    // Mock spawn to return a fake child process
+    (child_process.spawn as any).mockImplementation(() => {
+      const child = new EventEmitter();
+      (child as any).stdout = new EventEmitter();
+      (child as any).stderr = new EventEmitter();
+      (child as any).stdin = { write: vi.fn(), end: vi.fn() };
+      (child as any).kill = vi.fn();
+      
+      // Simulate immediate close
+      setTimeout(() => {
+        child.emit('close', 0);
+      }, 10);
+      
+      return child;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('injects CREWX_* environment variables in query', async () => {
+    await provider.query('test prompt', { agentId: 'test-agent', taskId: 'test-task' });
+    
+    expect(child_process.spawn).toHaveBeenCalled();
+    const calls = (child_process.spawn as any).mock.calls;
+    const env = calls[0][2].env;
+    
+    expect(env.CREWX_AGENT_ID).toBe('test-agent');
+    expect(env.CREWX_TASK_ID).toBe('test-task');
+    expect(env.CREWX_USER_ID).toBeDefined();
+  });
+
+  it('injects CREWX_* environment variables in execute', async () => {
+    await provider.execute('test prompt', { agentId: 'test-agent', taskId: 'test-task' });
+    
+    expect(child_process.spawn).toHaveBeenCalled();
+    const calls = (child_process.spawn as any).mock.calls;
+    const env = calls[0][2].env;
+    
+    expect(env.CREWX_AGENT_ID).toBe('test-agent');
+    expect(env.CREWX_TASK_ID).toBe('test-task');
+    expect(env.CREWX_USER_ID).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #53. Injects CREWX_USER_ID, CREWX_AGENT_ID, CREWX_TASK_ID into provider execution environment.