### PR TITLE
chore(#55): strengthen skill usage guide in default template

### DIFF
--- a/templates/agents/default.yaml
+++ b/templates/agents/default.yaml
@@ -129,6 +129,8 @@ layouts:
         1. Read the skill file using the file_path
         2. Follow the instructions in the skill document
         3. Apply the skill's guidance to the user's request
+
+        **IMPORTANT**: Do NOT guess skill usage. Always read SKILL.md first before using any skill.
         {{/if}}
         {{/if}}
 


### PR DESCRIPTION
## Summary
- Add IMPORTANT warning to skill usage guide in `templates/agents/default.yaml`
- Prevents agents from guessing skill usage patterns without reading SKILL.md

## Changes
Added warning message after skill usage instructions:
```
**IMPORTANT**: Do NOT guess skill usage. Always read SKILL.md first before using any skill.
```

## Test Plan
- [x] Build SDK succeeds
- [ ] Verify template renders correctly with skills enabled

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)