### PR TITLE
feat(#60): crewx skill CLI subcommand

### DIFF
--- a/packages/cli/src/app.module.ts
+++ b/packages/cli/src/app.module.ts
@@ -30,6 +30,7 @@ import { McpClientService } from './services/mcp-client.service';
 import { RemoteAgentService } from './services/remote-agent.service';
 import { ProviderBridgeService } from './services/provider-bridge.service';
 import { SkillLoaderService } from './services/skill-loader.service';
+import { SkillService } from './services/skill.service';
 import { TracingService } from './services/tracing.service';
 // SDK Layout Services (WBS-13 Phase 1)
 import { LayoutLoader, LayoutRenderer, PropsValidator } from '@sowonai/crewx-sdk';
@@ -109,6 +110,7 @@ export class AppModule {
         ToolCallService,
         AgentLoaderService,
         SkillLoaderService,
+        SkillService,
         McpClientService,
         RemoteAgentService,
         ProviderBridgeService,

--- a/packages/cli/src/cli-options.ts
+++ b/packages/cli/src/cli-options.ts
@@ -35,6 +35,10 @@ export interface CliOptions {
   templateSubcommand?: string; // init, list, show
   templateProjectName?: string; // Project name for init
   templateName?: string; // Template name for show
+  // Skill command options (crewx skill)
+  skillAction?: string; // list, info, or skill name
+  skillTarget?: string; // skill name (for info) or first arg
+  skillParams?: string[]; // Arguments for skill execution
   // Slack options
   slackAgent?: string; // Default agent for Slack bot
   slackMode?: 'query' | 'execute'; // Slack bot execution mode
@@ -45,6 +49,7 @@ export interface CliOptions {
   mcpToolName?: string;
   mcpParams?: string;
   // API keys removed for security - use environment variables or CLI tool authentication instead
+  rawArgs?: string[];
 }
 
 export function parseCliOptions(): CliOptions {
@@ -122,6 +127,21 @@ export function parseCliOptions(): CliOptions {
         type: 'string',
         default: 'wbs-automation',
         description: 'Template to use for init (wbs-automation, docusaurus-admin, dev-team)'
+      });
+    })
+    .command('skill [action] [target] [params...]', 'Manage and execute skills', (yargs) => {
+      yargs.positional('action', {
+        description: 'Action (list, info) or skill name to execute',
+        type: 'string'
+      });
+      yargs.positional('target', {
+        description: 'Skill name (for info) or first argument for skill',
+        type: 'string'
+      });
+      yargs.positional('params', {
+        description: 'Additional arguments for skill execution',
+        type: 'string',
+        array: true
       });
     })
     .command('agent [action]', 'Manage configured agents', (yargs) => {
@@ -298,6 +318,10 @@ export function parseCliOptions(): CliOptions {
     templateSubcommand: parsed.subcommand as string,
     templateProjectName: parsed.name as string,
     templateName: parsed.name as string,
+    // Skill options
+    skillAction: parsed.action as string,
+    skillTarget: parsed.target as string,
+    skillParams: parsed.params as unknown as string[],
     // Slack options
     slackAgent: parsed.agent as string,
     slackMode: (parsed.mode as 'query' | 'execute' | undefined) || 'query',
@@ -307,5 +331,6 @@ export function parseCliOptions(): CliOptions {
     key: resolvedKey,
     mcpToolName: secondaryCommand === 'call_tool' ? tertiaryValue : undefined,
     mcpParams: typeof parsed.params === 'string' ? parsed.params : undefined,
+    rawArgs: process.argv.slice(2),
   };
 }

--- a/packages/cli/src/cli/cli.handler.ts
+++ b/packages/cli/src/cli/cli.handler.ts
@@ -65,6 +65,11 @@ export class CLIHandler {
           await handleSlackFiles(app, args);
           break;
 
+        case 'skill':
+          const { handleSkill } = await import('./skill.handler');
+          await handleSkill(app, args);
+          break;
+
         case 'help':
           const { handleHelp } = await import('./help.handler');
           await handleHelp(app);

--- a/packages/cli/src/cli/skill.handler.ts
+++ b/packages/cli/src/cli/skill.handler.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@nestjs/common';
+import { CliOptions } from '../cli-options';
+import { SkillService } from '../services/skill.service';
+
+export async function handleSkill(app: any, args: CliOptions) {
+  const logger = new Logger('SkillHandler');
+  const skillService = app.get(SkillService);
+
+  const action = args.skillAction;
+
+  if (!action || action === 'list' || action === 'ls') {
+    // List skills
+    const skills = await skillService.discover();
+    if (skills.length === 0) {
+      console.log('No skills found in skills/ directory.');
+      return;
+    }
+
+    console.log('\nAvailable Skills:\n');
+    console.log('| Name | Version | Description |');
+    console.log('|------|---------|-------------|');
+
+    for (const skill of skills) {
+      console.log(`| ${skill.name} | ${skill.version} | ${skill.description} |`);
+    }
+    console.log('');
+    return;
+  }
+
+  if (action === 'info') {
+    // Show info
+    const skillName = args.skillTarget;
+    if (!skillName) {
+      logger.error('Please specify a skill name for info command.');
+      return;
+    }
+
+    const skill = await skillService.getSkill(skillName);
+    if (!skill) {
+      logger.error(`Skill '${skillName}' not found.`);
+      process.exit(1);
+    }
+
+    console.log(`\n${skill.name} (v${skill.version})`);
+    console.log(`${'─'.repeat(40)}`);
+    console.log(`Description: ${skill.description}`);
+    console.log(`Entry Point: ${skill.entryPoint}`);
+    console.log(`Path: ${skill.path}`);
+    console.log('');
+    return;
+  }
+
+  // Execute skill
+  const skillName = action;
+  
+  // Use rawArgs to get accurate arguments including flags like --help
+  let skillArgs: string[] = [];
+  if (args.rawArgs) {
+      const skillIndex = args.rawArgs.indexOf('skill');
+      // args.rawArgs[skillIndex] == 'skill'
+      // args.rawArgs[skillIndex+1] == skillName
+      // args start from skillIndex + 2
+      if (skillIndex !== -1 && args.rawArgs.length > skillIndex + 1) {
+          // Verify that the next arg is indeed the skill name
+          if (args.rawArgs[skillIndex + 1] === skillName) {
+              skillArgs = args.rawArgs.slice(skillIndex + 2);
+          }
+      }
+  }
+
+  // Fallback to parsed params if rawArgs extraction didn't produce anything
+  // Note: This fallback might still miss flags if yargs consumed them, but it's safe default
+  if (skillArgs.length === 0 && (args.skillTarget || (args.skillParams && args.skillParams.length > 0))) {
+      skillArgs = [args.skillTarget, ...(args.skillParams || [])].filter(x => x !== undefined && x !== null) as string[];
+  }
+
+  try {
+    await skillService.execute(skillName, skillArgs);
+  } catch (error) {
+    logger.error(`Failed to execute skill '${skillName}': ${error}`);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -32,8 +32,15 @@ process.stderr.on('error', (err: NodeJS.ErrnoException) => {
 });
 
 // If --help or -h is used, force the command to be 'help'
+// UNLESS it is 'skill' command with a specific skill/action target (to pass --help to the skill)
 if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  args.command = 'help';
+  const isSkillExecution = args.command === 'skill' && 
+    args.skillAction && 
+    !['list', 'ls', 'info'].includes(args.skillAction);
+    
+  if (!isSkillExecution) {
+    args.command = 'help';
+  }
 }
 
 async function cli() {

--- a/packages/cli/src/services/skill.service.ts
+++ b/packages/cli/src/services/skill.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseSkillManifestFromFile } from '@sowonai/crewx-sdk';
+import { spawn } from 'child_process';
+
+export interface SkillMetadata {
+  name: string;
+  description: string;
+  version: string;
+  entryPoint: string;
+  path: string;
+}
+
+@Injectable()
+export class SkillService {
+  private readonly logger = new Logger(SkillService.name);
+  private skillsDirs: string[];
+
+  constructor() {
+    this.skillsDirs = [
+      path.join(process.cwd(), 'skills'),
+      path.join(process.cwd(), '.crewx', 'skills')
+    ];
+  }
+
+  async discover(): Promise<SkillMetadata[]> {
+    const skills: SkillMetadata[] = [];
+    
+    for (const dirPath of this.skillsDirs) {
+        if (!fs.existsSync(dirPath)) continue;
+
+        try {
+            const dirs = fs.readdirSync(dirPath, { withFileTypes: true })
+                .filter(d => d.isDirectory());
+
+            for (const dir of dirs) {
+                const skillPath = path.join(dirPath, dir.name);
+                const skillMdPath = path.join(skillPath, 'SKILL.md');
+
+                if (fs.existsSync(skillMdPath)) {
+                    try {
+                        // Use SDK to parse frontmatter
+                        const manifest = parseSkillManifestFromFile(skillMdPath, {
+                            loadContent: false,
+                            validationMode: 'lenient'
+                        });
+                        
+                        const entryPoint = this.detectEntryPoint(skillPath, dir.name);
+
+                        if (entryPoint) {
+                            skills.push({
+                                name: manifest.metadata.name || dir.name,
+                                description: manifest.metadata.description || '',
+                                version: manifest.metadata.version || '0.0.0',
+                                entryPoint,
+                                path: skillPath,
+                            });
+                        }
+                    } catch (e) {
+                        this.logger.debug(`Failed to parse SKILL.md in ${skillPath}: ${e}`);
+                    }
+                }
+            }
+        } catch (e) {
+            this.logger.warn(`Failed to read skills directory ${dirPath}: ${e}`);
+        }
+    }
+    return skills;
+  }
+
+  async getSkill(name: string): Promise<SkillMetadata | null> {
+    const skills = await this.discover();
+    return skills.find(s => s.name === name) || null;
+  }
+
+  private detectEntryPoint(skillPath: string, skillName: string): string | null {
+    const candidates = [
+      `${skillName}.js`,
+      `${skillName}.sh`,
+      `${skillName}.py`,
+      'index.js',
+      'main.js',
+    ];
+
+    for (const candidate of candidates) {
+      const fullPath = path.join(skillPath, candidate);
+      if (fs.existsSync(fullPath)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  async execute(name: string, args: string[]): Promise<{ code: number; output: string }> {
+    const skill = await this.getSkill(name);
+    if (!skill) {
+        throw new Error(`Skill '${name}' not found`);
+    }
+
+    const entryPath = path.join(skill.path, skill.entryPoint);
+    
+    return new Promise((resolve, reject) => {
+        let command: string;
+        let cmdArgs: string[];
+
+        if (skill.entryPoint.endsWith('.js')) {
+            command = 'node';
+            cmdArgs = [entryPath, ...args];
+        } else if (skill.entryPoint.endsWith('.sh')) {
+            command = 'sh';
+            cmdArgs = [entryPath, ...args];
+        } else if (skill.entryPoint.endsWith('.py')) {
+            command = 'python3';
+            cmdArgs = [entryPath, ...args];
+        } else {
+             reject(new Error(`Unsupported entry point: ${skill.entryPoint}`));
+             return;
+        }
+
+        const child = spawn(command, cmdArgs, {
+            cwd: skill.path,
+            stdio: 'inherit' 
+        });
+
+        child.on('close', (code) => {
+            resolve({ code: code || 0, output: '' });
+        });
+
+        child.on('error', (err) => {
+            reject(err);
+        });
+    });
+  }
+}


### PR DESCRIPTION
Feat #60: Implement crewx skill CLI subcommand compatible with Claude Code skill system.

## Changes
- Added `skill.service.ts` for skill discovery and execution
- Added `skill.handler.ts` for CLI command handling
- Updated `cli-options.ts` to support `skill` command and raw args passthrough
- Registered `skill` command in `cli.handler.ts` and `app.module.ts`

## Verified
- `crewx skill list`
- `crewx skill info <name>`
- `crewx skill <name> [args]` (with flags)
