### PR TITLE
feat(#60): skill add/remove commands (Phase 2)

### DIFF
--- a/packages/cli/src/cli/skill.handler.ts
+++ b/packages/cli/src/cli/skill.handler.ts
@@ -11,17 +11,30 @@ export async function handleSkill(app: any, args: CliOptions) {
   if (!action || action === 'list' || action === 'ls') {
     // List skills
     const skills = await skillService.discover();
+    const registry = skillService.getRegistry();
+
     if (skills.length === 0) {
-      console.log('No skills found in skills/ directory.');
+      console.log('No skills found.');
+      console.log('\nTo add skills:');
+      console.log('  crewx skill add npm:<package>     # Install from npm');
+      console.log('  crewx skill add template:<name>   # Create from template');
+      console.log('\nAvailable templates: ' + skillService.getAvailableTemplates().join(', '));
       return;
     }
 
     console.log('\nAvailable Skills:\n');
-    console.log('| Name | Version | Description |');
-    console.log('|------|---------|-------------|');
+    console.log('| Name | Version | Source | Description |');
+    console.log('|------|---------|--------|-------------|');
 
     for (const skill of skills) {
-      console.log(`| ${skill.name} | ${skill.version} | ${skill.description} |`);
+      // Determine source
+      let source = 'custom';
+      if (registry.skills[skill.name]) {
+        const entry = registry.skills[skill.name];
+        source = entry.source === 'npm' ? `npm:${entry.package}` :
+                 entry.source === 'template' ? `template:${entry.template}` : entry.source;
+      }
+      console.log(`| ${skill.name} | ${skill.version} | ${source} | ${skill.description} |`);
     }
     console.log('');
     return;
@@ -41,12 +54,85 @@ export async function handleSkill(app: any, args: CliOptions) {
       process.exit(1);
     }
 
+    const registry = skillService.getRegistry();
+    const regEntry = registry.skills[skillName];
+
     console.log(`\n${skill.name} (v${skill.version})`);
     console.log(`${'─'.repeat(40)}`);
     console.log(`Description: ${skill.description}`);
     console.log(`Entry Point: ${skill.entryPoint}`);
     console.log(`Path: ${skill.path}`);
+    if (regEntry) {
+      console.log(`Source: ${regEntry.source}${regEntry.package ? `:${regEntry.package}` : regEntry.template ? `:${regEntry.template}` : ''}`);
+      console.log(`Installed: ${regEntry.installed}`);
+    } else {
+      console.log(`Source: custom (skills/ directory)`);
+    }
     console.log('');
+    return;
+  }
+
+  // skill add <source>
+  if (action === 'add') {
+    const source = args.skillTarget;
+    if (!source) {
+      console.log('Usage: crewx skill add <source>');
+      console.log('');
+      console.log('Sources:');
+      console.log('  npm:<package>     Install skill from npm package');
+      console.log('  template:<name>   Create skill from built-in template');
+      console.log('  github:<repo>     (Coming in v0.8.1) Install from GitHub');
+      console.log('');
+      console.log('Available templates: ' + skillService.getAvailableTemplates().join(', '));
+      console.log('');
+      console.log('Examples:');
+      console.log('  crewx skill add npm:@crewx/memory');
+      console.log('  crewx skill add template:hello');
+      return;
+    }
+
+    const result = await skillService.add(source);
+    if (result.success) {
+      console.log(`✓ ${result.message}`);
+      console.log(`\nRun 'crewx skill list' to see installed skills.`);
+    } else {
+      console.error(`✗ ${result.message}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // skill remove <name>
+  if (action === 'remove' || action === 'rm') {
+    const skillName = args.skillTarget;
+    if (!skillName) {
+      console.log('Usage: crewx skill remove <name>');
+      console.log('');
+      console.log('Removes an installed skill from .crewx/skills/');
+      console.log('Note: Custom skills in skills/ directory must be removed manually.');
+      return;
+    }
+
+    const result = await skillService.remove(skillName);
+    if (result.success) {
+      console.log(`✓ ${result.message}`);
+    } else {
+      console.error(`✗ ${result.message}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // skill templates - list available templates
+  if (action === 'templates') {
+    console.log('\nAvailable Templates:\n');
+    console.log('| Name | Description |');
+    console.log('|------|-------------|');
+    console.log('| hello | Simple greeting demo skill |');
+    console.log('| memory | Key-value memory storage skill |');
+    console.log('| api | HTTP API client skill |');
+    console.log('');
+    console.log('Usage: crewx skill add template:<name>');
     return;
   }
 

--- a/packages/cli/src/services/skill.service.spec.ts
+++ b/packages/cli/src/services/skill.service.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { SkillService } from './skill.service';
+
+// Access private methods for testing by casting to any
+const getService = () => {
+    return new SkillService() as any;
+};
+
+describe('SkillService Security', () => {
+  describe('validatePackageName', () => {
+    it('should reject package names starting with hyphen', () => {
+      const service = getService();
+      // Current implementation allows these, so this test should fail before fix
+      expect(service.validatePackageName('-g')).toBe(false);
+      expect(service.validatePackageName('--unsafe')).toBe(false);
+    });
+
+    it('should accept valid package names', () => {
+      const service = getService();
+      expect(service.validatePackageName('safe-package')).toBe(true);
+      expect(service.validatePackageName('pkg-1')).toBe(true);
+      expect(service.validatePackageName('@scope/package')).toBe(true);
+    });
+  });
+
+  describe('validateSkillName', () => {
+    it('should reject dangerous path components', () => {
+      const service = getService();
+      // Current implementation might allow '.', so this test should fail before fix
+      expect(service.validateSkillName('.')).toBe(false);
+      expect(service.validateSkillName('..')).toBe(false);
+    });
+
+    it('should accept valid skill names', () => {
+      const service = getService();
+      expect(service.validateSkillName('my-skill')).toBe(true);
+      expect(service.validateSkillName('skill_123')).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/services/skill.service.ts
+++ b/packages/cli/src/services/skill.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 import { parseSkillManifestFromFile } from '@sowonai/crewx-sdk';
-import { spawn } from 'child_process';
+import { spawn, execSync } from 'child_process';
 
 export interface SkillMetadata {
   name: string;
@@ -10,18 +10,107 @@ export interface SkillMetadata {
   version: string;
   entryPoint: string;
   path: string;
+  source?: 'custom' | 'installed' | 'template';
 }
+
+export interface RegistryEntry {
+  source: 'npm' | 'template' | 'github';
+  package?: string;
+  template?: string;
+  version: string;
+  installed: string;
+}
+
+export interface SkillRegistry {
+  skills: Record<string, RegistryEntry>;
+}
+
+export type SkillSource =
+  | { type: 'npm'; package: string }
+  | { type: 'template'; name: string }
+  | { type: 'github'; repo: string; version?: string };
 
 @Injectable()
 export class SkillService {
   private readonly logger = new Logger(SkillService.name);
   private skillsDirs: string[];
+  private installedSkillsDir: string;
+  private crewxDir: string;
+  private registryPath: string;
 
   constructor() {
+    this.crewxDir = path.join(process.cwd(), '.crewx');
+    this.installedSkillsDir = path.join(this.crewxDir, 'skills');
+    this.registryPath = path.join(this.crewxDir, 'registry.json');
+
+    // Priority: custom skills > installed skills
     this.skillsDirs = [
       path.join(process.cwd(), 'skills'),
-      path.join(process.cwd(), '.crewx', 'skills')
+      this.installedSkillsDir
     ];
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Registry Management
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private loadRegistry(): SkillRegistry {
+    try {
+      if (fs.existsSync(this.registryPath)) {
+        const content = fs.readFileSync(this.registryPath, 'utf-8');
+        return JSON.parse(content);
+      }
+    } catch (e) {
+      this.logger.warn(`Failed to load registry: ${e}`);
+    }
+    return { skills: {} };
+  }
+
+  private saveRegistry(registry: SkillRegistry): void {
+    this.ensureCrewxDir();
+    fs.writeFileSync(this.registryPath, JSON.stringify(registry, null, 2));
+  }
+
+  private ensureCrewxDir(): void {
+    if (!fs.existsSync(this.crewxDir)) {
+      fs.mkdirSync(this.crewxDir, { recursive: true });
+    }
+  }
+
+  private ensureInstalledSkillsDir(): void {
+    this.ensureCrewxDir();
+    if (!fs.existsSync(this.installedSkillsDir)) {
+      fs.mkdirSync(this.installedSkillsDir, { recursive: true });
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Source Parsing
+  // ─────────────────────────────────────────────────────────────────────────
+
+  parseSource(source: string): SkillSource | null {
+    // npm:<package> - e.g., npm:@crewx/memory, npm:crewx-skill-memory
+    if (source.startsWith('npm:')) {
+      return { type: 'npm', package: source.slice(4) };
+    }
+    // template:<name> - e.g., template:memory, template:hello
+    if (source.startsWith('template:')) {
+      return { type: 'template', name: source.slice(9) };
+    }
+    // github:<owner/repo>[@version] - Phase 1.5
+    if (source.startsWith('github:')) {
+      const rest = source.slice(7);
+      const atIndex = rest.lastIndexOf('@');
+      if (atIndex > 0 && !rest.slice(0, atIndex).includes('/')) {
+        // Invalid format
+        return null;
+      }
+      if (atIndex > 0) {
+        return { type: 'github', repo: rest.slice(0, atIndex), version: rest.slice(atIndex + 1) };
+      }
+      return { type: 'github', repo: rest };
+    }
+    return null;
   }
 
   async discover(): Promise<SkillMetadata[]> {
@@ -132,5 +221,414 @@ export class SkillService {
             reject(err);
         });
     });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Skill Installation
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async add(sourceStr: string): Promise<{ success: boolean; name: string; message: string }> {
+    const source = this.parseSource(sourceStr);
+    if (!source) {
+      return {
+        success: false,
+        name: '',
+        message: `Invalid source format: ${sourceStr}. Use npm:<package>, template:<name>, or github:<owner/repo>`
+      };
+    }
+
+    switch (source.type) {
+      case 'npm':
+        return this.addFromNpm(source.package);
+      case 'template':
+        return this.addFromTemplate(source.name);
+      case 'github':
+        return {
+          success: false,
+          name: '',
+          message: 'GitHub source is planned for Phase 1.5 (v0.8.1+). Use npm: or template: for now.'
+        };
+      default:
+        return { success: false, name: '', message: `Unknown source type` };
+    }
+  }
+
+  private async addFromNpm(packageName: string): Promise<{ success: boolean; name: string; message: string }> {
+    this.ensureInstalledSkillsDir();
+
+    try {
+      // Create temp directory for npm install
+      const tempDir = path.join(this.crewxDir, '.tmp-install');
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true });
+      }
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      // Initialize package.json in temp dir
+      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'temp', private: true }));
+
+      // Install the package
+      this.logger.log(`Installing ${packageName} from npm...`);
+      execSync(`npm install ${packageName} --prefix "${tempDir}"`, {
+        stdio: 'inherit'
+      });
+
+      // Find the installed package
+      const nodeModulesPath = path.join(tempDir, 'node_modules');
+      const installedPkgPath = this.findInstalledPackage(nodeModulesPath, packageName);
+
+      if (!installedPkgPath) {
+        fs.rmSync(tempDir, { recursive: true });
+        return { success: false, name: '', message: `Failed to locate installed package: ${packageName}` };
+      }
+
+      // Check for SKILL.md
+      const skillMdPath = path.join(installedPkgPath, 'SKILL.md');
+      if (!fs.existsSync(skillMdPath)) {
+        fs.rmSync(tempDir, { recursive: true });
+        return { success: false, name: '', message: `Package ${packageName} does not contain a SKILL.md file` };
+      }
+
+      // Parse skill manifest
+      const manifest = parseSkillManifestFromFile(skillMdPath, {
+        loadContent: false,
+        validationMode: 'lenient'
+      });
+
+      const skillName = manifest.metadata.name || path.basename(installedPkgPath);
+      const skillVersion = manifest.metadata.version || '0.0.0';
+
+      // Check for existing custom skill (which takes priority)
+      const customSkillPath = path.join(process.cwd(), 'skills', skillName);
+      if (fs.existsSync(customSkillPath)) {
+        fs.rmSync(tempDir, { recursive: true });
+        return {
+          success: false,
+          name: skillName,
+          message: `Skill '${skillName}' already exists in skills/ directory (custom skills take priority)`
+        };
+      }
+
+      // Move to installed skills directory
+      const targetPath = path.join(this.installedSkillsDir, skillName);
+      if (fs.existsSync(targetPath)) {
+        // Remove existing installation for update
+        fs.rmSync(targetPath, { recursive: true });
+      }
+
+      // Copy package to installed skills
+      this.copyDir(installedPkgPath, targetPath);
+
+      // Clean up temp directory
+      fs.rmSync(tempDir, { recursive: true });
+
+      // Update registry
+      const registry = this.loadRegistry();
+      registry.skills[skillName] = {
+        source: 'npm',
+        package: packageName,
+        version: skillVersion,
+        installed: new Date().toISOString()
+      };
+      this.saveRegistry(registry);
+
+      return {
+        success: true,
+        name: skillName,
+        message: `Successfully installed ${skillName}@${skillVersion} from npm:${packageName}`
+      };
+    } catch (e) {
+      return { success: false, name: '', message: `Failed to install from npm: ${e}` };
+    }
+  }
+
+  private findInstalledPackage(nodeModulesPath: string, packageName: string): string | null {
+    // Handle scoped packages (e.g., @crewx/memory)
+    if (packageName.startsWith('@')) {
+      const parts = packageName.split('/');
+      const scope = parts[0];
+      const name = parts[1];
+      if (scope && name) {
+        const scopedPath = path.join(nodeModulesPath, scope, name);
+        if (fs.existsSync(scopedPath)) {
+          return scopedPath;
+        }
+      }
+    } else {
+      const directPath = path.join(nodeModulesPath, packageName);
+      if (fs.existsSync(directPath)) {
+        return directPath;
+      }
+    }
+    return null;
+  }
+
+  private copyDir(src: string, dest: string): void {
+    fs.mkdirSync(dest, { recursive: true });
+    const entries = fs.readdirSync(src, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const srcPath = path.join(src, entry.name);
+      const destPath = path.join(dest, entry.name);
+
+      if (entry.isDirectory()) {
+        // Skip node_modules
+        if (entry.name === 'node_modules') continue;
+        this.copyDir(srcPath, destPath);
+      } else {
+        fs.copyFileSync(srcPath, destPath);
+      }
+    }
+  }
+
+  private async addFromTemplate(templateName: string): Promise<{ success: boolean; name: string; message: string }> {
+    this.ensureInstalledSkillsDir();
+
+    // Built-in templates (stored in skills/ directory of the project)
+    const builtInTemplates: Record<string, { description: string; files: Record<string, string> }> = {
+      hello: {
+        description: 'Simple greeting demo skill',
+        files: {
+          'SKILL.md': `---
+name: {{name}}
+description: A simple greeting skill
+version: 0.0.1
+---
+
+# {{name}} Skill
+
+A simple greeting skill created from template.
+
+## Usage
+\`\`\`bash
+node skills/{{name}}/{{name}}.js [name]
+\`\`\`
+`,
+          '{{name}}.js': `#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log('Usage: node {{name}}.js [name]');
+  process.exit(0);
+}
+
+const name = args[0] || 'World';
+console.log(\`Hello, \${name}! (from {{name}} skill)\`);
+`
+        }
+      },
+      memory: {
+        description: 'Key-value memory storage skill',
+        files: {
+          'SKILL.md': `---
+name: {{name}}
+description: Simple key-value memory storage
+version: 0.0.1
+---
+
+# {{name}} Skill
+
+A simple key-value memory storage skill.
+
+## Commands
+- \`save <key> <value>\` - Save a value
+- \`load <key>\` - Load a value
+- \`list\` - List all keys
+- \`delete <key>\` - Delete a key
+`,
+          '{{name}}.js': `#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const dataFile = path.join(__dirname, 'data.json');
+
+function loadData() {
+  try {
+    return JSON.parse(fs.readFileSync(dataFile, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveData(data) {
+  fs.writeFileSync(dataFile, JSON.stringify(data, null, 2));
+}
+
+const [command, ...args] = process.argv.slice(2);
+
+switch (command) {
+  case 'save':
+    const data = loadData();
+    data[args[0]] = args.slice(1).join(' ');
+    saveData(data);
+    console.log(\`Saved: \${args[0]}\`);
+    break;
+  case 'load':
+    const stored = loadData();
+    console.log(stored[args[0]] || '(not found)');
+    break;
+  case 'list':
+    console.log(Object.keys(loadData()).join('\\n') || '(empty)');
+    break;
+  case 'delete':
+    const d = loadData();
+    delete d[args[0]];
+    saveData(d);
+    console.log(\`Deleted: \${args[0]}\`);
+    break;
+  default:
+    console.log('Usage: {{name}}.js <save|load|list|delete> [args]');
+}
+`
+        }
+      },
+      api: {
+        description: 'HTTP API client skill',
+        files: {
+          'SKILL.md': `---
+name: {{name}}
+description: HTTP API client skill
+version: 0.0.1
+---
+
+# {{name}} Skill
+
+An HTTP API client skill for making REST requests.
+
+## Commands
+- \`get <url>\` - GET request
+- \`post <url> <data>\` - POST request with JSON data
+`,
+          '{{name}}.js': `#!/usr/bin/env node
+
+const https = require('https');
+const http = require('http');
+
+const [method, url, ...rest] = process.argv.slice(2);
+
+if (!method || !url) {
+  console.log('Usage: {{name}}.js <get|post> <url> [data]');
+  process.exit(1);
+}
+
+const client = url.startsWith('https') ? https : http;
+
+const req = client.request(url, { method: method.toUpperCase() }, (res) => {
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => console.log(data));
+});
+
+if (method.toLowerCase() === 'post' && rest.length) {
+  req.setHeader('Content-Type', 'application/json');
+  req.write(rest.join(' '));
+}
+
+req.end();
+`
+        }
+      }
+    };
+
+    const template = builtInTemplates[templateName];
+    if (!template) {
+      const available = Object.keys(builtInTemplates).join(', ');
+      return {
+        success: false,
+        name: '',
+        message: `Template '${templateName}' not found. Available: ${available}`
+      };
+    }
+
+    // Generate a unique skill name if needed
+    let skillName = templateName;
+    let counter = 1;
+    while (fs.existsSync(path.join(this.installedSkillsDir, skillName)) ||
+           fs.existsSync(path.join(process.cwd(), 'skills', skillName))) {
+      skillName = `${templateName}-${counter}`;
+      counter++;
+    }
+
+    // Create skill directory
+    const targetPath = path.join(this.installedSkillsDir, skillName);
+    fs.mkdirSync(targetPath, { recursive: true });
+
+    // Create files from template
+    for (const [fileNameTemplate, contentTemplate] of Object.entries(template.files)) {
+      const fileName = fileNameTemplate.replace(/\{\{name\}\}/g, skillName);
+      const content = contentTemplate.replace(/\{\{name\}\}/g, skillName);
+      const filePath = path.join(targetPath, fileName);
+      fs.writeFileSync(filePath, content);
+
+      // Make .js files executable
+      if (fileName.endsWith('.js')) {
+        fs.chmodSync(filePath, '755');
+      }
+    }
+
+    // Update registry
+    const registry = this.loadRegistry();
+    registry.skills[skillName] = {
+      source: 'template',
+      template: templateName,
+      version: '0.0.1',
+      installed: new Date().toISOString()
+    };
+    this.saveRegistry(registry);
+
+    return {
+      success: true,
+      name: skillName,
+      message: `Successfully created skill '${skillName}' from template '${templateName}' at .crewx/skills/${skillName}/`
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Skill Removal
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async remove(name: string): Promise<{ success: boolean; message: string }> {
+    // Check if it's an installed skill (in .crewx/skills/)
+    const installedPath = path.join(this.installedSkillsDir, name);
+    const registry = this.loadRegistry();
+
+    if (!fs.existsSync(installedPath)) {
+      // Check if it's a custom skill
+      const customPath = path.join(process.cwd(), 'skills', name);
+      if (fs.existsSync(customPath)) {
+        return {
+          success: false,
+          message: `'${name}' is a custom skill in skills/ directory. Remove it manually if intended.`
+        };
+      }
+      return { success: false, message: `Skill '${name}' not found in installed skills.` };
+    }
+
+    try {
+      // Remove the skill directory
+      fs.rmSync(installedPath, { recursive: true });
+
+      // Remove from registry
+      delete registry.skills[name];
+      this.saveRegistry(registry);
+
+      return { success: true, message: `Successfully removed skill '${name}'` };
+    } catch (e) {
+      return { success: false, message: `Failed to remove skill '${name}': ${e}` };
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Registry Query
+  // ─────────────────────────────────────────────────────────────────────────
+
+  getRegistry(): SkillRegistry {
+    return this.loadRegistry();
+  }
+
+  getAvailableTemplates(): string[] {
+    return ['hello', 'memory', 'api'];
   }
 }

--- a/packages/cli/src/services/skill.service.ts
+++ b/packages/cli/src/services/skill.service.ts
@@ -259,6 +259,11 @@ export class SkillService {
    * Invalid: anything with shell metacharacters
    */
   private validatePackageName(packageName: string): boolean {
+    // Prevent argument injection: package name must not start with a hyphen
+    if (packageName.startsWith('-')) {
+      return false;
+    }
+
     // npm package name regex: optional @scope/, name, optional @version
     // Allows: letters, numbers, -, _, ., @, /
     // Must not contain shell metacharacters: ; | & $ ` " ' \ ( ) { } [ ] < > ! # * ?
@@ -617,6 +622,11 @@ req.end();
    * Invalid: anything with path separators (.., /, \)
    */
   private validateSkillName(name: string): boolean {
+    // Prevent path traversal: explicitly reject . and ..
+    if (name === '.' || name === '..') {
+      return false;
+    }
+
     // Skill name should not contain path separators or traversal patterns
     if (name.includes('/') || name.includes('\\') || name.includes('..')) {
       return false;


### PR DESCRIPTION
## Summary

- Implements Phase 2 of issue #60: skill installation and removal
- `skill add npm:<package>` - Install skills from npm packages
- `skill add template:<name>` - Create skills from built-in templates (hello, memory, api)
- `skill remove <name>` - Remove installed skills from `.crewx/skills/`
- `.crewx/registry.json` - Tracks installed skill metadata (source, version, install date)
- `skill templates` - Lists available built-in templates

## Test plan

- [x] `crewx skill list` shows skills with source column
- [x] `crewx skill add template:api` creates skill in `.crewx/skills/`
- [x] `crewx skill info api` shows source and install date
- [x] `crewx skill remove api` removes installed skill
- [x] Custom skills in `skills/` directory are protected from removal
- [x] Build passes with no TypeScript errors

Fixes #60 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)