### PR TITLE
feat(#53): integrate TracingService in AgentRuntime (Phase 2)

### DIFF
--- a/packages/cli/src/crewx.tool.ts
+++ b/packages/cli/src/crewx.tool.ts
@@ -1,5 +1,5 @@
 import { PREFIX_TOOL_NAME, SERVER_NAME, getErrorMessage, getErrorStack, getTimeoutConfig, LayoutLoader, LayoutRenderer, RenderContext, AgentInfo, type ProviderResolutionResult, type ConversationMessage } from '@sowonai/crewx-sdk';
-import { Injectable, Logger, OnModuleInit, Inject } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, Inject, Optional } from '@nestjs/common';
 import { McpTool } from '@sowonai/nestjs-mcp-adapter';
 import { z } from 'zod';
 import * as fs from 'fs';
@@ -18,6 +18,7 @@ import { AgentLoaderService } from './services/agent-loader.service';
 import { RemoteAgentService } from './services/remote-agent.service';
 import { ProviderBridgeService, type ProviderBridgeAgentRuntime } from './services/provider-bridge.service';
 import { SkillLoaderService } from './services/skill-loader.service';
+import { TracingService } from './services/tracing.service';
 
 @Injectable()
 export class CrewXTool implements OnModuleInit {
@@ -128,6 +129,7 @@ export class CrewXTool implements OnModuleInit {
     private readonly skillLoaderService: SkillLoaderService,
     @Inject('LAYOUT_LOADER') private readonly layoutLoader: LayoutLoader,
     @Inject('LAYOUT_RENDERER') private readonly layoutRenderer: LayoutRenderer,
+    @Optional() private readonly tracingService?: TracingService,
   ) {}
 
   /**
@@ -750,6 +752,7 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
 
     // Load agent first to get correct provider
     let taskId: string;
+    let traceTaskId: string | null = null;
     try {
       // Dynamically load agent configuration using AgentLoaderService (includes plugin providers)
       const agents = await this.agentLoaderService.getAllAgents();
@@ -769,6 +772,14 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
       });
       const agentDescriptor = model ? `${agentId} (model: ${model})` : agentId;
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Started query agent ${agentDescriptor}` });
+
+      // Start tracing (graceful - won't crash if DB unavailable)
+      traceTaskId = this.tracingService?.createTask({
+        agent_id: agentId,
+        prompt: query,
+        mode: 'query',
+        metadata: { model, platform, provider: agentProvider },
+      }) ?? null;
 
       this.logger.log(`[${taskId}] Querying agent ${agentId}: ${query.substring(0, 50)}...`);
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Query: ${query.substring(0, 100)}...` });
@@ -1110,15 +1121,24 @@ ${query}
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Query completed. Success: ${response.success}` });
       this.taskManagementService.completeTask(taskId, response, response.success);
 
+      // Complete tracing (graceful - won't crash if DB unavailable)
+      if (traceTaskId) {
+        if (response.success) {
+          this.tracingService?.completeTask(traceTaskId, response.content);
+        } else {
+          this.tracingService?.failTask(traceTaskId, response.error || 'Unknown error');
+        }
+      }
+
       // Compose MCP response text (simple format for Slack)
-      const responseText = response.success 
-        ? response.content 
+      const responseText = response.success
+        ? response.content
         : `❌ **Error**\n\`\`\`${response.error}\`\`\`\n\nAgent: ${agentId} (${response.provider}) · Task ID: \`${taskId}\``;
 
       return {
         content: [
-          { 
-            type: 'text', 
+          {
+            type: 'text',
             text: responseText
           }
         ],
@@ -1135,6 +1155,11 @@ ${query}
 
     } catch (error) {
       const errorMessage = getErrorMessage(error);
+
+      // Fail tracing (graceful - won't crash if DB unavailable)
+      if (traceTaskId) {
+        this.tracingService?.failTask(traceTaskId, errorMessage);
+      }
 
       // Only log to task if taskId was successfully created
       if (taskId!) {
@@ -1266,6 +1291,7 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
 
     // Load agent first to get correct provider
     let taskId: string;
+    let traceTaskId: string | null = null;
     try {
       // Dynamically load agent configuration using AgentLoaderService (includes plugin providers)
       const agents = await this.agentLoaderService.getAllAgents();
@@ -1285,6 +1311,14 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
       });
       const agentDescriptor = model ? `${agentId} (model: ${model})` : agentId;
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Started execute agent ${agentDescriptor}` });
+
+      // Start tracing (graceful - won't crash if DB unavailable)
+      traceTaskId = this.tracingService?.createTask({
+        agent_id: agentId,
+        prompt: task,
+        mode: 'execute',
+        metadata: { model, platform, provider: agentProvider },
+      }) ?? null;
 
       this.logger.log(`[${taskId}] Executing agent ${agentId}: ${task.substring(0, 50)}...`);
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Task: ${task.substring(0, 100)}...` });
@@ -1618,6 +1652,15 @@ Task: ${task}
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Execution completed. Success: ${response.success}` });
       this.taskManagementService.completeTask(taskId, response, response.success);
 
+      // Complete tracing (graceful - won't crash if DB unavailable)
+      if (traceTaskId) {
+        if (response.success) {
+          this.tracingService?.completeTask(traceTaskId, response.content);
+        } else {
+          this.tracingService?.failTask(traceTaskId, response.error || 'Unknown error');
+        }
+      }
+
       // Compose MCP response text - Clean format for Slack
       // Only show the actual AI response content, not metadata
       const responseText = response.success ? response.content : `❌ Execution Failed: ${response.error}`;
@@ -1641,6 +1684,11 @@ Task: ${task}
 
     } catch (error) {
       const errorMessage = getErrorMessage(error);
+
+      // Fail tracing (graceful - won't crash if DB unavailable)
+      if (traceTaskId) {
+        this.tracingService?.failTask(traceTaskId, errorMessage);
+      }
 
       // Only log to task if taskId was successfully created
       if (taskId!) {

--- a/packages/cli/src/services/tracing.service.ts
+++ b/packages/cli/src/services/tracing.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Optional, Inject } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 import Database from 'better-sqlite3';
@@ -107,7 +107,9 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
   private db: Database.Database | null = null;
   private dbPath: string;
 
-  constructor(options?: TracingServiceOptions) {
+  constructor(
+    @Optional() @Inject('TRACING_OPTIONS') options?: TracingServiceOptions,
+  ) {
     if (options?.dbPath) {
       this.dbPath = options.dbPath;
     } else {

--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -489,6 +489,9 @@ Started: ${timestamp}
           ...process.env,
           LANG: 'en_US.UTF-8',
           LC_ALL: 'en_US.UTF-8',
+          CREWX_TASK_ID: taskId,
+          CREWX_AGENT_ID: options.agentId || '',
+          CREWX_USER_ID: process.env.USER || process.env.USERNAME || 'unknown',
           ...this.getEnv(),
         };
         if (process.platform === 'win32') {
@@ -708,6 +711,9 @@ Started: ${timestamp}
           ...process.env,
           LANG: 'en_US.UTF-8',
           LC_ALL: 'en_US.UTF-8',
+          CREWX_TASK_ID: taskId,
+          CREWX_AGENT_ID: options.agentId || '',
+          CREWX_USER_ID: process.env.USER || process.env.USERNAME || 'unknown',
           ...this.getEnv(),
         };
         if (process.platform === 'win32') {

--- a/packages/sdk/tests/unit/providers/base-ai-env.test.ts
+++ b/packages/sdk/tests/unit/providers/base-ai-env.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BaseAIProvider } from '../../../src/core/providers/base-ai.provider';
+import * as child_process from 'child_process';
+import { EventEmitter } from 'events';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execSync: vi.fn().mockReturnValue('/bin/echo'),
+}));
+
+class TestProvider extends BaseAIProvider {
+  name = 'cli/test';
+  getCliCommand() { return 'echo'; }
+  getDefaultArgs() { return []; }
+  getExecuteArgs() { return []; }
+  getNotInstalledMessage() { return 'error'; }
+}
+
+describe('BaseAIProvider Environment Variables', () => {
+  let provider: TestProvider;
+  
+  beforeEach(() => {
+    provider = new TestProvider('test');
+    // Mock spawn to return a fake child process
+    (child_process.spawn as any).mockImplementation(() => {
+      const child = new EventEmitter();
+      (child as any).stdout = new EventEmitter();
+      (child as any).stderr = new EventEmitter();
+      (child as any).stdin = { write: vi.fn(), end: vi.fn() };
+      (child as any).kill = vi.fn();
+      
+      // Simulate immediate close
+      setTimeout(() => {
+        child.emit('close', 0);
+      }, 10);
+      
+      return child;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('injects CREWX_* environment variables in query', async () => {
+    await provider.query('test prompt', { agentId: 'test-agent', taskId: 'test-task' });
+    
+    expect(child_process.spawn).toHaveBeenCalled();
+    const calls = (child_process.spawn as any).mock.calls;
+    const env = calls[0][2].env;
+    
+    expect(env.CREWX_AGENT_ID).toBe('test-agent');
+    expect(env.CREWX_TASK_ID).toBe('test-task');
+    expect(env.CREWX_USER_ID).toBeDefined();
+  });
+
+  it('injects CREWX_* environment variables in execute', async () => {
+    await provider.execute('test prompt', { agentId: 'test-agent', taskId: 'test-task' });
+    
+    expect(child_process.spawn).toHaveBeenCalled();
+    const calls = (child_process.spawn as any).mock.calls;
+    const env = calls[0][2].env;
+    
+    expect(env.CREWX_AGENT_ID).toBe('test-agent');
+    expect(env.CREWX_TASK_ID).toBe('test-task');
+    expect(env.CREWX_USER_ID).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Integrate TracingService with queryAgent() and executeAgent() methods
- Record agent execution traces to SQLite database (.crewx/traces.db)
- Graceful error handling - won't crash if DB unavailable

## Changes
- Import TracingService and inject via DI with @Optional decorator
- Add tracing start (createTask) at agent execution beginning
- Add tracing completion (completeTask/failTask) at success/failure points

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] `crewx q` execution creates trace record in `.crewx/traces.db`
- [x] Verify trace contains agent_id, prompt, mode, status

## Verification
```sql
-- Tested query
sqlite3 .crewx/traces.db "SELECT id, agent_id, mode, status FROM tasks LIMIT 5;"
-- Result: 98f0d230-...|claude|query|success
```

Fixes #53 (Phase 2: AgentRuntime integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)