### PR TITLE
fix(#77): unify task ID between TaskManagementService and TracingService

### DIFF
--- a/packages/cli/src/crewx.tool.ts
+++ b/packages/cli/src/crewx.tool.ts
@@ -784,7 +784,9 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
       // Start tracing (graceful - won't crash if DB unavailable)
       // Phase 3a: Pass extended fields to TracingService
       // Phase 3b: Add trace_id, parent_task_id, caller_agent_id for chain tracing
+      // Issue #77: Pass taskId from TaskManagementService to ensure ID consistency
       traceTaskId = this.tracingService?.createTask({
+        id: taskId,  // Use same ID as TaskManagementService for consistency
         agent_id: agentId,
         prompt: query,
         mode: 'query',
@@ -1340,7 +1342,9 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
       // Start tracing (graceful - won't crash if DB unavailable)
       // Phase 3a: Pass extended fields to TracingService
       // Phase 3b: Add trace_id, parent_task_id, caller_agent_id for chain tracing
+      // Issue #77: Pass taskId from TaskManagementService to ensure ID consistency
       traceTaskId = this.tracingService?.createTask({
+        id: taskId,  // Use same ID as TaskManagementService for consistency
         agent_id: agentId,
         prompt: task,
         mode: 'execute',

--- a/packages/cli/src/services/tracing.service.ts
+++ b/packages/cli/src/services/tracing.service.ts
@@ -75,6 +75,8 @@ export interface SpanRecord {
  * Task creation input
  */
 export interface CreateTaskInput {
+  /** Optional external ID. If provided, used as task ID; otherwise, auto-generated. */
+  id?: string;
   agent_id: string;
   user_id?: string;
   prompt: string;
@@ -331,13 +333,14 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
   /**
    * Create a new task record
    * Phase 3b: Token estimation removed - will be populated via JSON parsing in future
+   * Issue #77: Uses external id if provided, otherwise generates one
    */
   createTask(input: CreateTaskInput): string | null {
     if (!this.db) {
       return null;
     }
 
-    const id = this.generateId();
+    const id = input.id ?? this.generateId();
     const now = this.now();
 
     // Phase 3a: Merge provider_version into metadata if provided


### PR DESCRIPTION
## Summary
- Fix Task ID mismatch between log files and traces.db
- TracingService now accepts optional external ID, falling back to auto-generation
- Both query and execute modes pass the same taskId to TracingService

## Test Plan
- [x] Build succeeded
- [x] Ran `crewx q '@gemini 안녕'`
- [x] Verified log file ID and DB task ID match

### Test Evidence
```
Log file: task_1767619757570_837bg2jzx.log
DB query: sqlite3 .crewx/traces.db "SELECT id FROM tasks ORDER BY started_at DESC LIMIT 1;"
Result: task_1767619757570_837bg2jzx
```

Both IDs are identical - bug is fixed.

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)