### PR TITLE
feat(#82): enhance observability for 4 coding agents

### DIFF
--- a/packages/cli/src/crewx.tool.ts
+++ b/packages/cli/src/crewx.tool.ts
@@ -987,6 +987,12 @@ ${query}
         this.tracingService?.updateTaskRenderedPrompt(traceTaskId, fullPrompt);
       }
 
+      const promptLength = fullPrompt.length;
+      this.taskManagementService.addTaskLog(taskId, {
+        level: 'info',
+        message: `Prompt length: ${promptLength} characters`,
+      });
+
       let runtimeResult: ProviderBridgeAgentRuntime;
       let providerResolution: ProviderResolutionResult;
       let providerInput: string | undefined;
@@ -1145,11 +1151,53 @@ ${query}
         taskId: agentResult.metadata?.taskId ?? taskId,
         error: agentResult.metadata?.error,
         pid: agentResult.metadata?.pid as number | undefined,
+        command: agentResult.metadata?.command as string | undefined,
+        exitCode: agentResult.metadata?.exitCode as number | null | undefined,
+        durationMs: agentResult.metadata?.durationMs as number | undefined,
+        timeToFirstOutputMs: agentResult.metadata?.timeToFirstOutputMs as number | null | undefined,
       };
 
       // Phase 4: Update PID in trace record
       if (traceTaskId && response.pid) {
         this.tracingService?.updateTaskPid(traceTaskId, response.pid);
+      }
+
+      if (traceTaskId && response.command) {
+        this.tracingService?.updateTaskCodingAgentCommand(traceTaskId, response.command);
+      }
+
+      if (response.command) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `Coding agent command: ${response.command}`,
+        });
+      }
+      if (response.pid !== undefined) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `PID: ${response.pid ?? 'unknown'}`,
+        });
+      }
+      if (response.exitCode !== undefined) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `Exit code: ${response.exitCode ?? 'unknown'}`,
+        });
+      }
+      if (response.durationMs !== undefined) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `Duration: ${response.durationMs}ms`,
+        });
+      }
+      if (response.timeToFirstOutputMs !== undefined) {
+        const firstResponseText = response.timeToFirstOutputMs === null
+          ? 'unknown'
+          : `${response.timeToFirstOutputMs}ms`;
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `First response: ${firstResponseText}`,
+        });
       }
 
       // Handle task completion
@@ -1159,9 +1207,9 @@ ${query}
       // Complete tracing (graceful - won't crash if DB unavailable)
       if (traceTaskId) {
         if (response.success) {
-          this.tracingService?.completeTask(traceTaskId, response.content);
+          this.tracingService?.completeTask(traceTaskId, response.content, response.exitCode);
         } else {
-          this.tracingService?.failTask(traceTaskId, response.error || 'Unknown error');
+          this.tracingService?.failTask(traceTaskId, response.error || 'Unknown error', response.exitCode);
         }
       }
 
@@ -1551,6 +1599,12 @@ Task: ${task}
         this.tracingService?.updateTaskRenderedPrompt(traceTaskId, fullPrompt);
       }
 
+      const promptLength = fullPrompt.length;
+      this.taskManagementService.addTaskLog(taskId, {
+        level: 'info',
+        message: `Prompt length: ${promptLength} characters`,
+      });
+
       let runtimeResult: ProviderBridgeAgentRuntime;
       let providerResolution: ProviderResolutionResult;
       let providerInput: string | undefined;
@@ -1710,11 +1764,53 @@ Task: ${task}
         taskId: agentResult.metadata?.taskId ?? taskId,
         error: agentResult.metadata?.error,
         pid: agentResult.metadata?.pid as number | undefined,
+        command: agentResult.metadata?.command as string | undefined,
+        exitCode: agentResult.metadata?.exitCode as number | null | undefined,
+        durationMs: agentResult.metadata?.durationMs as number | undefined,
+        timeToFirstOutputMs: agentResult.metadata?.timeToFirstOutputMs as number | null | undefined,
       };
 
       // Phase 4: Update PID in trace record
       if (traceTaskId && response.pid) {
         this.tracingService?.updateTaskPid(traceTaskId, response.pid);
+      }
+
+      if (traceTaskId && response.command) {
+        this.tracingService?.updateTaskCodingAgentCommand(traceTaskId, response.command);
+      }
+
+      if (response.command) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `Coding agent command: ${response.command}`,
+        });
+      }
+      if (response.pid !== undefined) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `PID: ${response.pid ?? 'unknown'}`,
+        });
+      }
+      if (response.exitCode !== undefined) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `Exit code: ${response.exitCode ?? 'unknown'}`,
+        });
+      }
+      if (response.durationMs !== undefined) {
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `Duration: ${response.durationMs}ms`,
+        });
+      }
+      if (response.timeToFirstOutputMs !== undefined) {
+        const firstResponseText = response.timeToFirstOutputMs === null
+          ? 'unknown'
+          : `${response.timeToFirstOutputMs}ms`;
+        this.taskManagementService.addTaskLog(taskId, {
+          level: 'info',
+          message: `First response: ${firstResponseText}`,
+        });
       }
 
       // Handle task completion
@@ -1724,9 +1820,9 @@ Task: ${task}
       // Complete tracing (graceful - won't crash if DB unavailable)
       if (traceTaskId) {
         if (response.success) {
-          this.tracingService?.completeTask(traceTaskId, response.content);
+          this.tracingService?.completeTask(traceTaskId, response.content, response.exitCode);
         } else {
-          this.tracingService?.failTask(traceTaskId, response.error || 'Unknown error');
+          this.tracingService?.failTask(traceTaskId, response.error || 'Unknown error', response.exitCode);
         }
       }
 

--- a/packages/cli/src/services/tracing.service.ts
+++ b/packages/cli/src/services/tracing.service.ts
@@ -63,6 +63,8 @@ export interface TaskRecord {
   pid?: number;
   rendered_prompt?: string;
   command?: string;
+  coding_agent_command?: string;
+  exit_code?: number;
   logs?: TaskLogEntry[];
 }
 
@@ -110,6 +112,8 @@ export interface CreateTaskInput {
   pid?: number;
   rendered_prompt?: string;
   command?: string;
+  coding_agent_command?: string;
+  exit_code?: number;
 }
 
 /**
@@ -317,7 +321,9 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
    * Phase 4: Migrate schema to add enhanced task tracking columns
    * - pid: Process ID for running tasks
    * - rendered_prompt: Full rendered prompt (10MB limit handled in createTask)
-   * - command: CLI command executed
+   * - command: CrewX CLI command executed
+   * - coding_agent_command: Underlying coding agent CLI command executed
+   * - exit_code: CLI process exit code
    * - logs: JSON array of log entries for real-time storage
    */
   private migrateSchemaPhase4(): void {
@@ -327,6 +333,8 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
       { name: 'pid', type: 'INTEGER' },
       { name: 'rendered_prompt', type: 'TEXT' },
       { name: 'command', type: 'TEXT' },
+      { name: 'coding_agent_command', type: 'TEXT' },
+      { name: 'exit_code', type: 'INTEGER' },
       { name: 'logs', type: 'TEXT' }, // JSON array
     ];
 
@@ -398,7 +406,7 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
    * Create a new task record
    * Phase 3b: Token estimation removed - will be populated via JSON parsing in future
    * Issue #77: Uses external id if provided, otherwise generates one
-   * Phase 4: Added pid, rendered_prompt, command fields
+   * Phase 4: Added pid, rendered_prompt, command, coding_agent_command, exit_code fields
    */
   createTask(input: CreateTaskInput): string | null {
     if (!this.db) {
@@ -426,9 +434,9 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
           id, agent_id, user_id, prompt, mode, status, started_at, metadata,
           trace_id, parent_task_id, caller_agent_id, model, platform, crewx_version,
           input_tokens, output_tokens, cost_usd,
-          pid, rendered_prompt, command, logs
+          pid, rendered_prompt, command, coding_agent_command, exit_code, logs
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       stmt.run(
@@ -451,7 +459,9 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
         input.cost_usd ?? 0,
         input.pid ?? null,  // Phase 4: Process ID
         renderedPrompt,     // Phase 4: Rendered prompt (with 10MB limit)
-        input.command ?? null, // Phase 4: CLI command
+        input.command ?? null, // Phase 4: CrewX CLI command
+        input.coding_agent_command ?? null, // Phase 4: Coding agent CLI command
+        input.exit_code ?? null,
         '[]',               // Phase 4: Initialize logs as empty JSON array
       );
 
@@ -469,7 +479,7 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
    * Complete a task with success
    * Phase 3b: output_tokens left at 0 - will be populated via JSON parsing in future
    */
-  completeTask(taskId: string, result?: string): boolean {
+  completeTask(taskId: string, result?: string, exitCode?: number | null): boolean {
     if (!this.db) {
       return false;
     }
@@ -481,11 +491,12 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
         UPDATE tasks
         SET status = ?, result = ?, completed_at = ?,
             duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER),
-            output_tokens = ?
+            output_tokens = ?,
+            exit_code = ?
         WHERE id = ?
       `);
 
-      const info = stmt.run(TaskStatus.SUCCESS, result ?? null, now, now, 0, taskId);
+      const info = stmt.run(TaskStatus.SUCCESS, result ?? null, now, now, 0, exitCode ?? null, taskId);
       return info.changes > 0;
     } catch (error) {
       this.logger.error(
@@ -498,7 +509,7 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
   /**
    * Fail a task with error
    */
-  failTask(taskId: string, error: string): boolean {
+  failTask(taskId: string, error: string, exitCode?: number | null): boolean {
     if (!this.db) {
       return false;
     }
@@ -508,11 +519,12 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
       const stmt = this.db.prepare(`
         UPDATE tasks
         SET status = ?, error = ?, completed_at = ?,
-            duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER)
+            duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER),
+            exit_code = ?
         WHERE id = ?
       `);
 
-      const info = stmt.run(TaskStatus.FAILED, error, now, now, taskId);
+      const info = stmt.run(TaskStatus.FAILED, error, now, now, exitCode ?? null, taskId);
       return info.changes > 0;
     } catch (error: unknown) {
       this.logger.error(
@@ -546,6 +558,35 @@ export class TracingService implements OnModuleInit, OnModuleDestroy {
     } catch (error) {
       this.logger.error(
         `Failed to update PID for task ${taskId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Phase 4: Update coding agent command
+   * Stores the underlying CLI command executed for the coding agent
+   */
+  updateTaskCodingAgentCommand(taskId: string, command: string): boolean {
+    if (!this.db) {
+      return false;
+    }
+
+    try {
+      const stmt = this.db.prepare(`
+        UPDATE tasks
+        SET coding_agent_command = ?
+        WHERE id = ?
+      `);
+
+      const info = stmt.run(command, taskId);
+      if (info.changes > 0) {
+        this.logger.debug(`Updated task ${taskId} with coding agent command`);
+      }
+      return info.changes > 0;
+    } catch (error) {
+      this.logger.error(
+        `Failed to update coding agent command for task ${taskId}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return false;
     }

--- a/packages/sdk/src/core/agent/agent-runtime.ts
+++ b/packages/sdk/src/core/agent/agent-runtime.ts
@@ -321,6 +321,11 @@ export class AgentRuntime {
         context: request.context,
         messageCount: request.messages?.length ?? 0,
         model,
+        pid: aiResponse.pid,
+        exitCode: aiResponse.exitCode,
+        durationMs: aiResponse.durationMs,
+        timeToFirstOutputMs: aiResponse.timeToFirstOutputMs,
+        promptLength: aiResponse.promptLength,
       },
     };
   }

--- a/packages/sdk/src/core/providers/ai-provider.interface.d.ts
+++ b/packages/sdk/src/core/providers/ai-provider.interface.d.ts
@@ -25,6 +25,8 @@ export interface AIQueryOptions {
         metadata?: Record<string, any>;
     }>;
     pipedContext?: string;
+    /** Phase 3b: Trace ID for call chain tracking */
+    traceId?: string;
 }
 export interface AIResponse {
     content: string;
@@ -33,16 +35,28 @@ export interface AIResponse {
     success: boolean;
     error?: string;
     taskId?: string;
+    model?: string;
     toolCall?: {
         toolName: string;
         toolInput: any;
         toolResult: any;
     };
+    /** Phase 4: Process ID of the spawned CLI process */
+    pid?: number;
+    /** Exit code reported by the CLI process (null if unavailable). */
+    exitCode?: number | null;
+    /** Total duration from spawn to completion in milliseconds. */
+    durationMs?: number;
+    /** Time from spawn to first stdout/stderr output in milliseconds. */
+    timeToFirstOutputMs?: number;
+    /** Length of the prompt in characters. */
+    promptLength?: number;
 }
 export interface AIProvider {
     readonly name: string;
     isAvailable(): Promise<boolean>;
     query(prompt: string, options?: AIQueryOptions): Promise<AIResponse>;
+    execute(prompt: string, options?: AIQueryOptions): Promise<AIResponse>;
     getToolPath(): Promise<string | null>;
 }
 export declare class ProviderNotAvailableError extends Error {

--- a/packages/sdk/src/core/providers/ai-provider.interface.ts
+++ b/packages/sdk/src/core/providers/ai-provider.interface.ts
@@ -46,6 +46,14 @@ export interface AIResponse {
   };
   /** Phase 4: Process ID of the spawned CLI process */
   pid?: number;
+  /** Exit code reported by the CLI process (null if unavailable). */
+  exitCode?: number | null;
+  /** Total duration from spawn to completion in milliseconds. */
+  durationMs?: number;
+  /** Time from spawn to first stdout/stderr output in milliseconds. */
+  timeToFirstOutputMs?: number;
+  /** Length of the prompt in characters. */
+  promptLength?: number;
 }
 
 export interface AIProvider {

--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -516,7 +516,7 @@ Started: ${timestamp}
         }
 
         const startTime = Date.now();
-        let firstOutputAt: number | null = null;
+        let firstOutputAt: number | undefined = undefined;
 
         const child = spawn(executable, spawnArgs, {
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -534,7 +534,7 @@ Started: ${timestamp}
 
         child.stdout.on('data', (data: any) => {
           const output = data.toString();
-          if (firstOutputAt === null) {
+          if (firstOutputAt === undefined) {
             firstOutputAt = Date.now();
           }
           stdout += output;
@@ -543,7 +543,7 @@ Started: ${timestamp}
 
         child.stderr.on('data', (data: any) => {
           const output = data.toString();
-          if (firstOutputAt === null) {
+          if (firstOutputAt === undefined) {
             firstOutputAt = Date.now();
           }
           stderr += output;
@@ -554,7 +554,7 @@ Started: ${timestamp}
           exitCode = code;
           const completedAt = Date.now();
           const durationMs = completedAt - startTime;
-          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
+          const timeToFirstOutputMs = firstOutputAt !== undefined ? firstOutputAt - startTime : undefined;
           this.appendTaskLog(taskId, 'INFO', `Process closed with exit code: ${exitCode}`);
 
           if (stderr) {
@@ -636,7 +636,7 @@ Started: ${timestamp}
 
         child.on('error', (error: any) => {
           const durationMs = Date.now() - startTime;
-          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
+          const timeToFirstOutputMs = firstOutputAt !== undefined ? firstOutputAt - startTime : undefined;
           this.appendTaskLog(taskId, 'ERROR', `Process error: ${error.message}`);
           resolve({
             content: '',
@@ -671,7 +671,7 @@ Started: ${timestamp}
         // Timeout handling
         const timeout = setTimeout(() => {
           const durationMs = Date.now() - startTime;
-          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
+          const timeToFirstOutputMs = firstOutputAt !== undefined ? firstOutputAt - startTime : undefined;
           child.kill();
           resolve({
             content: '',
@@ -792,7 +792,7 @@ Started: ${timestamp}
         }
 
         const startTime = Date.now();
-        let firstOutputAt: number | null = null;
+        let firstOutputAt: number | undefined = undefined;
 
         const child = spawn(executable, spawnArgs, {
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -810,7 +810,7 @@ Started: ${timestamp}
 
         child.stdout.on('data', (data: any) => {
           const output = data.toString();
-          if (firstOutputAt === null) {
+          if (firstOutputAt === undefined) {
             firstOutputAt = Date.now();
           }
           stdout += output;
@@ -819,7 +819,7 @@ Started: ${timestamp}
 
         child.stderr.on('data', (data: any) => {
           const output = data.toString();
-          if (firstOutputAt === null) {
+          if (firstOutputAt === undefined) {
             firstOutputAt = Date.now();
           }
           stderr += output;
@@ -830,7 +830,7 @@ Started: ${timestamp}
           exitCode = code;
           const completedAt = Date.now();
           const durationMs = completedAt - startTime;
-          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
+          const timeToFirstOutputMs = firstOutputAt !== undefined ? firstOutputAt - startTime : undefined;
           this.appendTaskLog(taskId, 'INFO', `Process closed with exit code: ${exitCode}`);
 
           if (stderr) {
@@ -909,7 +909,7 @@ Started: ${timestamp}
 
         child.on('error', (error: any) => {
           const durationMs = Date.now() - startTime;
-          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
+          const timeToFirstOutputMs = firstOutputAt !== undefined ? firstOutputAt - startTime : undefined;
           this.appendTaskLog(taskId, 'ERROR', `Process error: ${error.message}`);
           resolve({
             content: '',
@@ -944,7 +944,7 @@ Started: ${timestamp}
         // Timeout handling
         const timeout = setTimeout(() => {
           const durationMs = Date.now() - startTime;
-          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
+          const timeToFirstOutputMs = firstOutputAt !== undefined ? firstOutputAt - startTime : undefined;
           child.kill();
           resolve({
             content: '',

--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -439,6 +439,7 @@ Started: ${timestamp}
     
     // Use command name directly - let the shell find it in PATH
     const executablePath = this.getCliCommand();
+    const promptLength = prompt.length;
 
     try {
       // Determine model to use (options.model > default_model)
@@ -476,12 +477,12 @@ Started: ${timestamp}
       // Create task log file
       this.createTaskLogFile(taskId, this.name, command, options.agentId, modelToUse);
       this.appendTaskLog(taskId, 'INFO', `Starting ${this.name} query mode`);
-      this.appendTaskLog(taskId, 'INFO', `Prompt length: ${prompt.length} characters`);
+      this.appendTaskLog(taskId, 'INFO', `Prompt length: ${promptLength} characters`);
       
       // Log prompt content (entire content for debugging)
       this.appendTaskLog(taskId, 'INFO', `Prompt content:\n${prompt}`);
 
-      this.logger.log(`Executing ${this.name} with prompt (length: ${prompt.length})`);
+      this.logger.log(`Executing ${this.name} with prompt (length: ${promptLength})`);
 
       return new Promise((resolve) => {
         // Set UTF-8 encoding to handle Korean/Unicode correctly across all platforms
@@ -514,6 +515,9 @@ Started: ${timestamp}
           useShell = true;
         }
 
+        const startTime = Date.now();
+        let firstOutputAt: number | null = null;
+
         const child = spawn(executable, spawnArgs, {
           stdio: ['pipe', 'pipe', 'pipe'],
           cwd: options.workingDirectory || process.cwd(),
@@ -530,18 +534,27 @@ Started: ${timestamp}
 
         child.stdout.on('data', (data: any) => {
           const output = data.toString();
+          if (firstOutputAt === null) {
+            firstOutputAt = Date.now();
+          }
           stdout += output;
           this.appendTaskLog(taskId, 'STDOUT', output);
         });
 
         child.stderr.on('data', (data: any) => {
           const output = data.toString();
+          if (firstOutputAt === null) {
+            firstOutputAt = Date.now();
+          }
           stderr += output;
           this.appendTaskLog(taskId, 'STDERR', output);
         });
 
         child.on('close', (code: any) => {
           exitCode = code;
+          const completedAt = Date.now();
+          const durationMs = completedAt - startTime;
+          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
           this.appendTaskLog(taskId, 'INFO', `Process closed with exit code: ${exitCode}`);
 
           if (stderr) {
@@ -560,6 +573,10 @@ Started: ${timestamp}
               success: true,
               taskId,
               pid: childPid,
+              exitCode,
+              durationMs,
+              timeToFirstOutputMs,
+              promptLength,
             });
             return;
           }
@@ -577,6 +594,10 @@ Started: ${timestamp}
               error: `${this.name} CLI failed: ${errorMessage}`,
               taskId,
               pid: childPid,
+              exitCode,
+              durationMs,
+              timeToFirstOutputMs,
+              promptLength,
             });
             return;
           }
@@ -606,10 +627,16 @@ Started: ${timestamp}
             success: true,
             taskId,
             pid: childPid,
+            exitCode,
+            durationMs,
+            timeToFirstOutputMs,
+            promptLength,
           });
         });
 
         child.on('error', (error: any) => {
+          const durationMs = Date.now() - startTime;
+          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
           this.appendTaskLog(taskId, 'ERROR', `Process error: ${error.message}`);
           resolve({
             content: '',
@@ -619,6 +646,10 @@ Started: ${timestamp}
             error: error.code === 'ENOENT' ? this.getNotInstalledMessage() : error.message,
             taskId,
             pid: childPid,
+            exitCode: null,
+            durationMs,
+            timeToFirstOutputMs,
+            promptLength,
           });
         });
 
@@ -639,6 +670,8 @@ Started: ${timestamp}
 
         // Timeout handling
         const timeout = setTimeout(() => {
+          const durationMs = Date.now() - startTime;
+          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
           child.kill();
           resolve({
             content: '',
@@ -648,6 +681,10 @@ Started: ${timestamp}
             error: `${this.name} CLI timeout`,
             taskId,
             pid: childPid,
+            exitCode: null,
+            durationMs,
+            timeToFirstOutputMs,
+            promptLength,
           });
         }, options.timeout || this.getDefaultQueryTimeout());
 
@@ -663,6 +700,8 @@ Started: ${timestamp}
         error: error.message || 'Unknown error occurred',
         taskId,
         // No pid available in catch block
+        exitCode: null,
+        promptLength,
       };
     }
   }
@@ -672,6 +711,7 @@ Started: ${timestamp}
     
     // Use command name directly - let the shell find it in PATH
     const executablePath = this.getCliCommand();
+    const promptLength = prompt.length;
 
     try {
       // Determine model to use (options.model > default_model)
@@ -710,7 +750,7 @@ Started: ${timestamp}
       this.appendTaskLog(taskId, 'INFO', `Execute Args: ${JSON.stringify(this.getExecuteArgs())}`);
       this.appendTaskLog(taskId, 'INFO', `Final Args: ${JSON.stringify(args)}`);
       this.appendTaskLog(taskId, 'INFO', `Starting ${this.name} execute mode`);
-      this.appendTaskLog(taskId, 'INFO', `Prompt length: ${prompt.length} characters`);
+      this.appendTaskLog(taskId, 'INFO', `Prompt length: ${promptLength} characters`);
 
       // Log prompt content
       const promptPreview = prompt.length > this.logConfig.promptMaxLength ?
@@ -718,7 +758,7 @@ Started: ${timestamp}
         prompt;
       this.appendTaskLog(taskId, 'INFO', `Prompt content:\n${promptPreview}`);
 
-      this.logger.log(`Executing ${this.name} in execute mode (length: ${prompt.length})`);
+      this.logger.log(`Executing ${this.name} in execute mode (length: ${promptLength})`);
 
       return new Promise((resolve) => {
         // Set UTF-8 encoding to handle Korean/Unicode correctly across all platforms
@@ -751,6 +791,9 @@ Started: ${timestamp}
           useShell = true;
         }
 
+        const startTime = Date.now();
+        let firstOutputAt: number | null = null;
+
         const child = spawn(executable, spawnArgs, {
           stdio: ['pipe', 'pipe', 'pipe'],
           cwd: options.workingDirectory || process.cwd(),
@@ -767,18 +810,27 @@ Started: ${timestamp}
 
         child.stdout.on('data', (data: any) => {
           const output = data.toString();
+          if (firstOutputAt === null) {
+            firstOutputAt = Date.now();
+          }
           stdout += output;
           this.appendTaskLog(taskId, 'STDOUT', output);
         });
 
         child.stderr.on('data', (data: any) => {
           const output = data.toString();
+          if (firstOutputAt === null) {
+            firstOutputAt = Date.now();
+          }
           stderr += output;
           this.appendTaskLog(taskId, 'STDERR', output);
         });
 
         child.on('close', (code: any) => {
           exitCode = code;
+          const completedAt = Date.now();
+          const durationMs = completedAt - startTime;
+          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
           this.appendTaskLog(taskId, 'INFO', `Process closed with exit code: ${exitCode}`);
 
           if (stderr) {
@@ -797,6 +849,10 @@ Started: ${timestamp}
               success: true,
               taskId,
               pid: childPid,
+              exitCode,
+              durationMs,
+              timeToFirstOutputMs,
+              promptLength,
             });
             return;
           }
@@ -814,6 +870,10 @@ Started: ${timestamp}
               error: `${this.name} CLI execute failed: ${errorMessage}`,
               taskId,
               pid: childPid,
+              exitCode,
+              durationMs,
+              timeToFirstOutputMs,
+              promptLength,
             });
             return;
           }
@@ -840,10 +900,16 @@ Started: ${timestamp}
             success: true,
             taskId,
             pid: childPid,
+            exitCode,
+            durationMs,
+            timeToFirstOutputMs,
+            promptLength,
           });
         });
 
         child.on('error', (error: any) => {
+          const durationMs = Date.now() - startTime;
+          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
           this.appendTaskLog(taskId, 'ERROR', `Process error: ${error.message}`);
           resolve({
             content: '',
@@ -853,6 +919,10 @@ Started: ${timestamp}
             error: error.code === 'ENOENT' ? this.getNotInstalledMessage() : error.message,
             taskId,
             pid: childPid,
+            exitCode: null,
+            durationMs,
+            timeToFirstOutputMs,
+            promptLength,
           });
         });
 
@@ -873,6 +943,8 @@ Started: ${timestamp}
 
         // Timeout handling
         const timeout = setTimeout(() => {
+          const durationMs = Date.now() - startTime;
+          const timeToFirstOutputMs = firstOutputAt !== null ? firstOutputAt - startTime : null;
           child.kill();
           resolve({
             content: '',
@@ -882,6 +954,10 @@ Started: ${timestamp}
             error: `${this.name} CLI execute timeout`,
             taskId,
             pid: childPid,
+            exitCode: null,
+            durationMs,
+            timeToFirstOutputMs,
+            promptLength,
           });
         }, options.timeout || this.getDefaultExecuteTimeout());
 
@@ -897,6 +973,8 @@ Started: ${timestamp}
         error: error.message || 'Unknown error occurred',
         taskId,
         // No pid available in catch block
+        exitCode: null,
+        promptLength,
       };
     }
   }


### PR DESCRIPTION
## Summary
- Add `coding_agent_command` column to traces.db for CLI command logging
- Add `exit_code` column to track process exit status
- Extend AIResponse with detailed metrics (exitCode, durationMs, timeToFirstOutputMs, promptLength)
- Update TracingService with schema migration and new update methods
- Enhanced logging in CrewXTool for all 4 coding agents (Claude, Gemini, Codex, Copilot)

## Test plan
- [ ] Run `npm run build` - verify no type errors
- [ ] Run `npm run test:cli` and `npm run test:sdk`
- [ ] Execute `crewx query` with each provider and verify traces.db contains new columns
- [ ] Verify `coding_agent_command`, `exit_code`, and enhanced logs are populated

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)