### PR TITLE
fix(#84): add span creation for crewx skill run CLI command

### DIFF
--- a/packages/cli/src/cli/skill.handler.ts
+++ b/packages/cli/src/cli/skill.handler.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { CliOptions } from '../cli-options';
 import { SkillService } from '../services/skill.service';
+import { TracingService, SpanKind } from '../services/tracing.service';
 
 export async function handleSkill(app: any, args: CliOptions) {
   const logger = new Logger('SkillHandler');
@@ -192,9 +193,54 @@ export async function handleSkill(app: any, args: CliOptions) {
       }
   }
 
+  // Issue #84: Create span for CLI subprocess tracking
+  // When agent runs `crewx skill run <name>`, create span if CREWX_TASK_ID is set
+  const taskId = process.env.CREWX_TASK_ID;
+  let tracingService: TracingService | null = null;
+  let spanId: string | null = null;
+
+  if (taskId) {
+    try {
+      tracingService = new TracingService();
+      tracingService.onModuleInit();
+
+      if (tracingService.isEnabled()) {
+        spanId = tracingService.createSpan({
+          task_id: taskId,
+          name: `skill:${skillName}`,
+          kind: SpanKind.INTERNAL,
+          input: JSON.stringify({ skill: skillName, args: skillArgs }),
+          attributes: {
+            source: 'cli',
+            command: `crewx skill run ${skillName} ${skillArgs.join(' ')}`.trim(),
+          },
+        });
+
+        // Mark that span was created by CLI handler to prevent duplicate in skill.service.ts
+        if (spanId) {
+          process.env.CREWX_SKILL_SPAN_CREATED = 'true';
+        }
+      }
+    } catch (error) {
+      logger.warn(`Failed to initialize tracing for skill: ${error}`);
+    }
+  }
+
   try {
-    await skillService.execute(skillName!, skillArgs);
+    const result = await skillService.execute(skillName!, skillArgs);
+
+    // Complete span on success
+    if (spanId && tracingService) {
+      tracingService.completeSpan(spanId, JSON.stringify({
+        code: result.code,
+        output_length: result.output?.length || 0,
+      }));
+    }
   } catch (error) {
+    // Fail span on error
+    if (spanId && tracingService) {
+      tracingService.failSpan(spanId, String(error));
+    }
     logger.error(`Failed to execute skill '${skillName}': ${error}`);
     process.exit(1);
   }

--- a/packages/cli/src/services/skill.service.ts
+++ b/packages/cli/src/services/skill.service.ts
@@ -218,12 +218,14 @@ export class SkillService {
     const entryPath = path.join(skill.path, entryPoint);
 
     // Phase 3c: Get task_id from environment variable for span tracking
+    // Issue #84: Skip span creation if CLI handler already created one
     const taskId = process.env.CREWX_TASK_ID;
+    const spanAlreadyCreated = process.env.CREWX_SKILL_SPAN_CREATED === 'true';
     let spanId: string | null = null;
     const startTime = Date.now();
 
-    // Create span if we have a task_id and tracing is enabled
-    if (taskId && this.tracingService?.isEnabled()) {
+    // Create span if we have a task_id, tracing is enabled, and no span was created by CLI handler
+    if (taskId && this.tracingService?.isEnabled() && !spanAlreadyCreated) {
       spanId = this.tracingService.createSpan({
         task_id: taskId,
         name: `skill:${name}`,


### PR DESCRIPTION
## Summary
- Add TracingService integration to `skill.handler.ts` for CLI subprocess tracking
- Create span when `CREWX_TASK_ID` environment variable is set
- Track skill execution in spans table for observability
- Prevent duplicate spans with `CREWX_SKILL_SPAN_CREATED` flag

## Problem
When an agent runs `crewx skill run <name>` via bash subprocess, the execution was not recorded in the spans table because:
- `skill.service.ts`'s `createSpan` only works when called via `SkillService.run()` internally
- CLI subprocess runs in a separate process without parent task context

## Solution
- Add span creation logic in `skill.handler.ts` (CLI entry point)
- Check `CREWX_TASK_ID` environment variable to link span to parent task
- Use `CREWX_SKILL_SPAN_CREATED` flag to prevent duplicate spans between handler and service

## Test plan
- [x] Build succeeds
- [x] Span is created when `CREWX_TASK_ID` is set
- [x] No duplicate spans (only 1 span per skill execution)

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)