### PR TITLE
fix(#84): add span creation for crewx skill run CLI command

### DIFF
--- a/packages/cli/src/crewx.tool.ts
+++ b/packages/cli/src/crewx.tool.ts
@@ -771,6 +771,8 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
         prompt: query,
         agentId: agentId
       });
+      // Issue #84: Set CREWX_TASK_ID for child processes (skill runs, etc.)
+      process.env.CREWX_TASK_ID = taskId;
       const agentDescriptor = model ? `${agentId} (model: ${model})` : agentId;
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Started query agent ${agentDescriptor}` });
 
@@ -1392,6 +1394,8 @@ Please ensure the MCP client is sending the correct JSON-RPC request format:
         prompt: task,
         agentId: agentId
       });
+      // Issue #84: Set CREWX_TASK_ID for child processes (skill runs, etc.)
+      process.env.CREWX_TASK_ID = taskId;
       const agentDescriptor = model ? `${agentId} (model: ${model})` : agentId;
       this.taskManagementService.addTaskLog(taskId, { level: 'info', message: `Started execute agent ${agentDescriptor}` });
 


### PR DESCRIPTION
## Summary
- Add `process.env.CREWX_TASK_ID = taskId` right after task creation in both query and execute functions
- This ensures child processes (skill runs) can access the parent task ID for proper span recording

## Test plan
- [ ] Run `crewx x "@agent crewx skill run status"` 
- [ ] Check `sqlite3 .crewx/traces.db "SELECT * FROM spans;"` shows the skill span
- [ ] Verify span's task_id matches parent agent's task_id

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)