### PR TITLE
fix(#89): bridge provider stdout/stderr logs to tracing

### DIFF
--- a/packages/cli/src/ai-provider.service.ts
+++ b/packages/cli/src/ai-provider.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import {
   AIProvider,
   AIQueryOptions,
@@ -32,8 +32,9 @@ import {
 import { DynamicProviderFactory } from './providers/dynamic-provider.factory';
 import { ConfigService } from './services/config.service';
 import { ToolCallService } from './services/tool-call.service';
-import { createLoggerAdapter } from './providers/logger.adapter';
+import { createLoggerAdapter, createTaskLogHandler } from './providers/logger.adapter';
 import { CREWX_VERSION } from './version';
+import { TracingService } from './services/tracing.service';
 
 @Injectable()
 export class AIProviderService implements OnModuleInit {
@@ -51,6 +52,7 @@ export class AIProviderService implements OnModuleInit {
     private readonly toolCallService: ToolCallService,
     private readonly dynamicProviderFactory: DynamicProviderFactory,
     private readonly configService: ConfigService,
+    @Optional() private readonly tracingService?: TracingService,
   ) {}
 
   async onModuleInit() {
@@ -63,26 +65,32 @@ export class AIProviderService implements OnModuleInit {
   }
 
   private createBuiltInProviders(): BaseAIProvider[] {
+    const taskLogHandler = createTaskLogHandler(this.tracingService);
+
     return [
       new SdkClaudeProvider({
         logger: createLoggerAdapter('ClaudeProvider'),
         toolCallHandler: this.toolCallService,
         crewxVersion: CREWX_VERSION,
+        taskLogHandler,
       }),
       new SdkGeminiProvider({
         logger: createLoggerAdapter('GeminiProvider'),
         toolCallHandler: this.toolCallService,
         crewxVersion: CREWX_VERSION,
+        taskLogHandler,
       }),
       new SdkCopilotProvider({
         logger: createLoggerAdapter('CopilotProvider'),
         toolCallHandler: this.toolCallService,
         crewxVersion: CREWX_VERSION,
+        taskLogHandler,
       }),
       new SdkCodexProvider({
         logger: createLoggerAdapter('CodexProvider'),
         toolCallHandler: this.toolCallService,
         crewxVersion: CREWX_VERSION,
+        taskLogHandler,
       }),
     ];
   }

--- a/packages/cli/src/providers/dynamic-provider.factory.ts
+++ b/packages/cli/src/providers/dynamic-provider.factory.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { BaseDynamicProviderFactory } from '@sowonai/crewx-sdk';
-import { createLoggerAdapter } from './logger.adapter';
+import { createLoggerAdapter, createTaskLogHandler } from './logger.adapter';
 import { CREWX_VERSION } from '../version';
+import { TracingService } from '../services/tracing.service';
 
 /**
  * CLI-specific DynamicProviderFactory
@@ -19,10 +20,11 @@ export class DynamicProviderFactory extends BaseDynamicProviderFactory {
     'eval', 'exec', 'source',
   ];
 
-  constructor() {
+  constructor(@Optional() private readonly tracingService?: TracingService) {
     super({
       logger: createLoggerAdapter(DynamicProviderFactory.name),
       crewxVersion: CREWX_VERSION,
+      taskLogHandler: createTaskLogHandler(tracingService),
     });
   }
 

--- a/packages/cli/src/providers/logger.adapter.ts
+++ b/packages/cli/src/providers/logger.adapter.ts
@@ -6,7 +6,8 @@
  */
 
 import { Logger } from '@nestjs/common';
-import type { LoggerLike } from '@sowonai/crewx-sdk';
+import type { LoggerLike, ProviderTaskLogEntry, ProviderTaskLogHandler } from '@sowonai/crewx-sdk';
+import type { TaskLogEntry, TracingService } from '../services/tracing.service';
 
 /**
  * Create a logger function that wraps a NestJS Logger instance
@@ -64,5 +65,40 @@ export function createLoggerAdapter(context: string): LoggerLike {
         }
       }
     },
+  };
+}
+
+export function createTaskLogHandler(tracingService?: TracingService): ProviderTaskLogHandler | undefined {
+  if (!tracingService) {
+    return undefined;
+  }
+
+  const knownTasks = new Set<string>();
+  const missingTasks = new Set<string>();
+
+  return (entry: ProviderTaskLogEntry) => {
+    if (missingTasks.has(entry.taskId)) {
+      return;
+    }
+
+    if (!knownTasks.has(entry.taskId)) {
+      const task = tracingService.getTask(entry.taskId);
+      if (!task) {
+        missingTasks.add(entry.taskId);
+        return;
+      }
+      knownTasks.add(entry.taskId);
+    }
+
+    if (entry.level !== 'STDOUT' && entry.level !== 'STDERR') {
+      return;
+    }
+
+    const level: TaskLogEntry['level'] = entry.level === 'STDOUT' ? 'stdout' : 'stderr';
+    tracingService.appendTaskLog(entry.taskId, {
+      timestamp: entry.timestamp,
+      level,
+      message: entry.message,
+    });
   };
 }

--- a/packages/cli/src/providers/logger.adapter.ts
+++ b/packages/cli/src/providers/logger.adapter.ts
@@ -73,21 +73,44 @@ export function createTaskLogHandler(tracingService?: TracingService): ProviderT
     return undefined;
   }
 
-  const knownTasks = new Set<string>();
-  const missingTasks = new Set<string>();
+  const TASK_CACHE_LIMIT = 1000;
+  const knownTasks = new Map<string, true>();
+  const missingTasks = new Map<string, true>();
+
+  const touchTask = (cache: Map<string, true>, taskId: string): boolean => {
+    if (!cache.has(taskId)) {
+      return false;
+    }
+    cache.delete(taskId);
+    cache.set(taskId, true);
+    return true;
+  };
+
+  const rememberTask = (cache: Map<string, true>, taskId: string): void => {
+    if (cache.has(taskId)) {
+      cache.delete(taskId);
+    }
+    cache.set(taskId, true);
+    if (cache.size > TASK_CACHE_LIMIT) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) {
+        cache.delete(oldest);
+      }
+    }
+  };
 
   return (entry: ProviderTaskLogEntry) => {
-    if (missingTasks.has(entry.taskId)) {
+    if (touchTask(missingTasks, entry.taskId)) {
       return;
     }
 
-    if (!knownTasks.has(entry.taskId)) {
+    if (!touchTask(knownTasks, entry.taskId)) {
       const task = tracingService.getTask(entry.taskId);
       if (!task) {
-        missingTasks.add(entry.taskId);
+        rememberTask(missingTasks, entry.taskId);
         return;
       }
-      knownTasks.add(entry.taskId);
+      rememberTask(knownTasks, entry.taskId);
     }
 
     if (entry.level !== 'STDOUT' && entry.level !== 'STDERR') {

--- a/packages/cli/src/providers/logger.adapter.ts
+++ b/packages/cli/src/providers/logger.adapter.ts
@@ -75,7 +75,6 @@ export function createTaskLogHandler(tracingService?: TracingService): ProviderT
 
   const TASK_CACHE_LIMIT = 1000;
   const knownTasks = new Map<string, true>();
-  const missingTasks = new Map<string, true>();
 
   const touchTask = (cache: Map<string, true>, taskId: string): boolean => {
     if (!cache.has(taskId)) {
@@ -100,14 +99,9 @@ export function createTaskLogHandler(tracingService?: TracingService): ProviderT
   };
 
   return (entry: ProviderTaskLogEntry) => {
-    if (touchTask(missingTasks, entry.taskId)) {
-      return;
-    }
-
     if (!touchTask(knownTasks, entry.taskId)) {
       const task = tracingService.getTask(entry.taskId);
       if (!task) {
-        rememberTask(missingTasks, entry.taskId);
         return;
       }
       rememberTask(knownTasks, entry.taskId);

--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { getTimeoutConfig, type TimeoutConfig } from '../../config/timeout.config';
 import { getLogConfig, type LogConfig } from '../../config/log.config';
 import type { AIProvider, AIQueryOptions, AIResponse } from './ai-provider.interface';
-import type { BaseAIProviderOptions, LoggerLike } from './base-ai.types';
+import type { BaseAIProviderOptions, LoggerLike, ProviderTaskLogHandler } from './base-ai.types';
 import type { ToolCallHandler } from './tool-call.types';
 
 /**
@@ -35,6 +35,7 @@ export abstract class BaseAIProvider implements AIProvider {
   protected toolCallHandler?: ToolCallHandler;
   private readonly logsDir: string;
   private readonly crewxVersion: string;
+  private readonly taskLogHandler?: ProviderTaskLogHandler;
   private cachedPath: string | null = null;
   protected readonly timeoutConfig: TimeoutConfig;
   protected readonly logConfig: LogConfig;
@@ -46,6 +47,7 @@ export abstract class BaseAIProvider implements AIProvider {
     this.logConfig = options.logConfig ?? getLogConfig();
     this.logsDir = options.logsDir ?? join(process.cwd(), '.crewx', 'logs');
     this.crewxVersion = options.crewxVersion ?? 'unknown';
+    this.taskLogHandler = options.taskLogHandler;
 
     // Create log directory
     try {
@@ -423,14 +425,30 @@ Started: ${timestamp}
   }
 
   protected appendTaskLog(taskId: string, level: 'STDOUT' | 'STDERR' | 'INFO' | 'ERROR', message: string): void {
+    const safeTaskId = taskId.replace(/[\\/]/g, '_');
+    const logFile = join(this.logsDir, `${safeTaskId}.log`);
+    const timestamp = new Date();
+    const logEntry = `[${timestamp.toLocaleString()}] ${level}: ${message}\n`;
+
     try {
-      const safeTaskId = taskId.replace(/[\\/]/g, '_');
-      const logFile = join(this.logsDir, `${safeTaskId}.log`);
-      const timestamp = new Date().toLocaleString();
-      const logEntry = `[${timestamp}] ${level}: ${message}\n`;
       appendFileSync(logFile, logEntry, 'utf8');
     } catch (error) {
       this.logger.error(`Failed to append to task log ${taskId}:`, error);
+    }
+
+    if (this.taskLogHandler) {
+      try {
+        this.taskLogHandler({
+          taskId,
+          timestamp: timestamp.toISOString(),
+          level,
+          message,
+        });
+      } catch (error) {
+        this.logger.warn(
+          `Task log handler failed for ${taskId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
   }
 

--- a/packages/sdk/src/core/providers/base-ai.types.ts
+++ b/packages/sdk/src/core/providers/base-ai.types.ts
@@ -8,6 +8,17 @@ export interface LoggerLike {
   error(message: string | Error, ...optionalParams: any[]): void;
 }
 
+export type ProviderTaskLogLevel = 'STDOUT' | 'STDERR' | 'INFO' | 'ERROR';
+
+export interface ProviderTaskLogEntry {
+  taskId: string;
+  timestamp: string;
+  level: ProviderTaskLogLevel;
+  message: string;
+}
+
+export type ProviderTaskLogHandler = (entry: ProviderTaskLogEntry) => void;
+
 export interface BaseAIProviderOptions {
   logger?: LoggerLike;
   toolCallHandler?: ToolCallHandler;
@@ -15,6 +26,7 @@ export interface BaseAIProviderOptions {
   timeoutConfig?: TimeoutConfig;
   logConfig?: LogConfig;
   crewxVersion?: string;
+  taskLogHandler?: ProviderTaskLogHandler;
 }
 
 export type AIProviderConfig = BaseAIProviderOptions;

--- a/packages/sdk/src/core/providers/dynamic-provider.factory.ts
+++ b/packages/sdk/src/core/providers/dynamic-provider.factory.ts
@@ -5,7 +5,7 @@ import {
   type AIResponse,
 } from './ai-provider.interface';
 import { getTimeoutConfig } from '../../config/timeout.config';
-import type { LoggerLike } from './base-ai.types';
+import type { LoggerLike, ProviderTaskLogHandler } from './base-ai.types';
 import { APIProviderConfig, API_PROVIDER_TYPES, APIProviderType } from '../../types/api-provider.types';
 
 class ConsoleLogger implements LoggerLike {
@@ -80,6 +80,7 @@ export type DynamicProviderConfig = PluginProviderConfig | RemoteProviderConfig 
 export interface DynamicProviderFactoryOptions {
   logger?: LoggerLike;
   crewxVersion?: string;
+  taskLogHandler?: ProviderTaskLogHandler;
 }
 
 /**
@@ -91,10 +92,12 @@ export class BaseDynamicProviderFactory {
   protected readonly logger: LoggerLike;
   protected readonly timeoutConfig = getTimeoutConfig();
   protected readonly crewxVersion: string;
+  protected readonly taskLogHandler?: ProviderTaskLogHandler;
 
   constructor(options: DynamicProviderFactoryOptions = {}) {
     this.logger = options.logger ?? new ConsoleLogger('DynamicProviderFactory');
     this.crewxVersion = options.crewxVersion ?? 'unknown';
+    this.taskLogHandler = options.taskLogHandler;
   }
 
   /**
@@ -181,6 +184,7 @@ export class BaseDynamicProviderFactory {
       constructor() {
         super(`DynamicProvider:${ProviderNamespace.PLUGIN}/${config.id}`, {
           crewxVersion: factory.crewxVersion,
+          taskLogHandler: factory.taskLogHandler,
         });
       }
 
@@ -290,6 +294,7 @@ export class BaseDynamicProviderFactory {
       constructor() {
         super(`RemoteProvider:${ProviderNamespace.REMOTE}/${config.id}`, {
           crewxVersion: factory.crewxVersion,
+          taskLogHandler: factory.taskLogHandler,
         });
       }
 
@@ -668,7 +673,9 @@ export class BaseDynamicProviderFactory {
       readonly name = config.provider;
 
       constructor() {
-        super(`APIProvider:${config.provider}`);
+        super(`APIProvider:${config.provider}`, {
+          taskLogHandler: factory.taskLogHandler,
+        });
       }
 
       protected getCliCommand(): string {

--- a/packages/sdk/src/index.d.ts
+++ b/packages/sdk/src/index.d.ts
@@ -9,7 +9,7 @@ export { ProviderNamespace, BuiltInProviders, ProviderNotAvailableError, } from 
 export type { ProviderNamespaceType, AIProvider, AIQueryOptions, AIResponse, } from './core/providers/ai-provider.interface';
 export { BaseAIProvider } from './core/providers/base-ai.provider';
 export { ClaudeProvider, GeminiProvider, CopilotProvider, CodexProvider, BaseDynamicProviderFactory, MockProvider, createProviderFromConfig, } from './core/providers';
-export type { BaseAIProviderOptions, LoggerLike, AIProviderConfig, } from './core/providers/base-ai.types';
+export type { BaseAIProviderOptions, LoggerLike, AIProviderConfig, ProviderTaskLogEntry, ProviderTaskLogHandler, ProviderTaskLogLevel, } from './core/providers/base-ai.types';
 export type { PluginProviderConfig, RemoteProviderConfig, DynamicProviderConfig, DynamicProviderFactoryOptions, } from './core/providers/dynamic-provider.factory';
 export type { ProviderConfig, ProviderInput, ProviderResolutionResult, } from './types/provider.types';
 export { createCrewxAgent, loadAgentConfigFromYaml, loadAgentConfigFromFile, resolveProvider, } from './core/agent';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -90,6 +90,9 @@ export type {
   BaseAIProviderOptions,
   LoggerLike,
   AIProviderConfig,
+  ProviderTaskLogEntry,
+  ProviderTaskLogHandler,
+  ProviderTaskLogLevel,
 } from './core/providers/base-ai.types';
 export type {
   PluginProviderConfig,


### PR DESCRIPTION
## Summary
- forward SDK provider task logs to CLI tracing service
- map STDOUT/STDERR entries into traces.db logs with level preservation
- expose task log handler types for provider wiring

## Testing
- not run (not requested)

Fixes #89