### PR TITLE
[Fix] CLI execute 기본 타임아웃 30분으로 변경

### DIFF
--- a/packages/cli/src/crewx.tool.ts
+++ b/packages/cli/src/crewx.tool.ts
@@ -1806,7 +1806,7 @@ Task: ${task}
             model: modelToUse,
             options: {
               workingDirectory: workingDir,
-              timeout: 1_200_000,
+              timeout: 1_800_000,
               additionalArgs: agentOptions,
               taskId,
               pipedContext: structuredPayload,


### PR DESCRIPTION
## Summary
CLI execute 기본 타임아웃을 20분에서 30분으로 변경

## Changes
- `packages/cli/src/crewx.tool.ts:1809` 라인 수정
  - 기존: `timeout: 1_200_000` (20분)
  - 변경: `timeout: 1_800_000` (30분)

## Background
- jarvis 에이전트가 웹 검색 작업 중 타임아웃 발생
- flow.js에서는 이미 30분 타임아웃 사용 중
- CLI 기본값이 20분으로 되어있어 불일치 발생

## Benefits
- 장시간 실행 작업(웹 검색, 복잡한 분석 등)에서 타임아웃 방지
- flow.js와 일관성 유지
- 운영 안정성 향상

## Test Plan
- [ ] 기존 기능 정상 동작 확인
- [ ] 장시간 실행 작업 타임아웃 없이 완료되는지 확인

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)