### PR TITLE
chore(#118): sync skills from crewx-sowonlabs

### DIFF
--- a/crewx.yaml
+++ b/crewx.yaml
@@ -220,8 +220,8 @@ agents:
       GIT_AUTHOR_NAME: "{{agent.name}}"
       GIT_AUTHOR_EMAIL: "crewx+{{agent.id}}@sowonlabs.com"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     skills:
       include:
         - tsserver
@@ -417,8 +417,8 @@ agents:
     team: "QA Team"
     description: "QA team leader who manages testing strategy, coordinates test execution, and makes release decisions"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     skills:
       include:
         - wbs
@@ -469,8 +469,8 @@ agents:
     description: "Specialized tester for analyzing and improving the CrewX project"
     working_directory: "."
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     skills:
       include:
         - memory-v2
@@ -505,8 +505,8 @@ agents:
       GIT_AUTHOR_NAME: "{{agent.name}}"
       GIT_AUTHOR_EMAIL: "crewx+{{agent.id}}@sowonlabs.com"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     skills:
       include:
         - memory-v2
@@ -542,8 +542,8 @@ agents:
     team: "Management"
     description: "개발팀장 - 이슈 할당, 에이전트 조율, 프로젝트 현황 관리"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     skills:
       include:
         - wbs
@@ -590,8 +590,8 @@ agents:
     description: "Specialized developer for analyzing the SowonFlow project (LangGraph-based production version)"
     working_directory: "/Users/doha/git/sowonai/packages/sowonflow"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     inline:
       type: "agent"
       provider: "cli/claude"
@@ -673,8 +673,8 @@ agents:
     description: "Specialized developer for analyzing Google's Gemini CLI source code"
     working_directory: "/Users/doha/git/gemini-cli"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     inline:
       type: "agent"
       provider: "cli/claude"
@@ -745,8 +745,8 @@ agents:
     description: "Mastra framework expert who analyzes Agent, Tool, and tool calling implementation"
     working_directory: "/Users/doha/git/mastra"
     options:
-      query: ["--verbose"]
-      execute: ["--verbose", "--dangerously-skip-permissions"]
+      query: ["--verbose", "--output-format", "stream-json"]
+      execute: ["--verbose", "--dangerously-skip-permissions", "--output-format", "stream-json"]
     inline:
       type: "agent"
       provider: "cli/claude"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crewx-monorepo",
   "private": true,
-  "version": "0.8.0-rc.27",
+  "version": "0.8.0-rc.28",
   "license": "Apache-2.0",
   "description": "CrewX monorepo workspace",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sowonai/crewx-cli",
-  "version": "0.8.0-rc.27",
+  "version": "0.8.0-rc.28",
   "license": "MIT",
   "engines": {
     "node": ">=20.19.0"
@@ -72,7 +72,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "@slack/bolt": "^4.4.0",
     "@slack/web-api": "^7.10.0",
-    "@sowonai/crewx-sdk": "^0.8.0-rc.26",
+    "@sowonai/crewx-sdk": "^0.8.0-rc.28",
     "@sowonai/nestjs-mcp-adapter": "^0.1.3",
     "@types/js-yaml": "^4.0.9",
     "@types/mdast": "^4.0.4",

--- a/packages/crewx/package.json
+++ b/packages/crewx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewx",
-  "version": "0.8.0-rc.26",
+  "version": "0.8.0-rc.28",
   "license": "MIT",
   "engines": {
     "node": ">=20.19.0"
@@ -22,7 +22,7 @@
     "test:unit": "npm run test"
   },
   "dependencies": {
-    "@sowonai/crewx-cli": "^0.8.0-rc.26"
+    "@sowonai/crewx-cli": "^0.8.0-rc.28"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sowonai/crewx-sdk",
-  "version": "0.8.0-rc.27",
+  "version": "0.8.0-rc.28",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.19.0"

--- a/skills/lib/bm25-search.js
+++ b/skills/lib/bm25-search.js
@@ -1,0 +1,142 @@
+/**
+ * BM25 검색 공용 모듈
+ *
+ * memory-v2의 BM25 검색 로직을 범용적으로 사용할 수 있도록 추출한 모듈
+ *
+ * Usage:
+ *   const { createSearchEngine, search } = require('./bm25-search.js');
+ *
+ *   // 방법 1: 재사용 가능한 엔진 생성
+ *   const engine = createSearchEngine({ summary: 3, tags: 2, body: 1 });
+ *   engine.addDoc({ summary: 'test', tags: 'foo bar', body: 'content' }, 0);
+ *   engine.consolidate();
+ *   const results = engine.search('test');
+ *
+ *   // 방법 2: 일회성 검색 (내부에서 엔진 생성)
+ *   const results = search(docs, 'keyword', { summary: 3, tags: 2 });
+ */
+
+const bm25 = require('wink-bm25-text-search');
+const nlp = require('wink-nlp-utils');
+
+/**
+ * BM25 검색 엔진 생성
+ * @param {Object} fieldWeights - 필드별 가중치 (예: { summary: 3, tags: 2, body: 1 })
+ * @returns {Object} wink-bm25-text-search 엔진 인스턴스
+ */
+function createSearchEngine(fieldWeights = {}) {
+  const engine = bm25();
+
+  // 필드 가중치 설정
+  engine.defineConfig({ fldWeights: fieldWeights });
+
+  // 전처리 태스크 정의 (영어 기본)
+  engine.definePrepTasks([
+    nlp.string.lowerCase,
+    nlp.string.tokenize0,
+    nlp.tokens.removeWords,
+    nlp.tokens.stem
+  ]);
+
+  return engine;
+}
+
+/**
+ * 문서 배열에서 BM25 검색 수행
+ * @param {Array} docs - 검색할 문서 배열 (각 문서는 fieldWeights의 키에 해당하는 속성 보유)
+ * @param {String} query - 검색 쿼리
+ * @param {Object} fieldWeights - 필드별 가중치 (예: { summary: 3, tags: 2, body: 1 })
+ * @param {Object} options - 추가 옵션
+ * @param {Number} options.maxBodyLength - body 필드 최대 길이 (기본: 500)
+ * @param {Boolean} options.returnScores - 점수 포함 여부 (기본: true)
+ * @returns {Array} 검색 결과 (점수 내림차순 정렬)
+ */
+function search(docs, query, fieldWeights = { summary: 3, tags: 2, body: 1 }, options = {}) {
+  const { maxBodyLength = 500, returnScores = true } = options;
+
+  if (!docs || docs.length === 0) {
+    return [];
+  }
+
+  // 엔진 생성 및 설정
+  const engine = createSearchEngine(fieldWeights);
+
+  // 문서 인덱싱
+  docs.forEach((doc, idx) => {
+    const indexDoc = {};
+
+    // fieldWeights에 정의된 필드만 인덱싱
+    for (const field of Object.keys(fieldWeights)) {
+      let value = doc[field];
+
+      // 배열인 경우 문자열로 변환
+      if (Array.isArray(value)) {
+        value = value.join(' ');
+      }
+
+      // body는 길이 제한
+      if (field === 'body' && value && typeof value === 'string') {
+        value = value.substring(0, maxBodyLength);
+      }
+
+      indexDoc[field] = value || '';
+    }
+
+    engine.addDoc(indexDoc, idx);
+  });
+
+  // 검색 실행
+  engine.consolidate();
+  const searchResults = engine.search(query);
+
+  // 결과 변환
+  if (returnScores) {
+    return searchResults.map(([idx, score]) => ({
+      ...docs[idx],
+      _score: Math.round(score * 100) / 100
+    }));
+  } else {
+    return searchResults.map(([idx]) => docs[idx]);
+  }
+}
+
+/**
+ * 한글 키워드 매칭 검색 (BM25 대신 단순 단어 매칭)
+ * @param {Array} docs - 검색할 문서 배열
+ * @param {String} query - 검색 쿼리
+ * @param {Array} fields - 검색할 필드 목록 (예: ['summary', 'tags', 'body'])
+ * @returns {Array} 검색 결과 (매치 카운트 내림차순 정렬)
+ */
+function koreanKeywordSearch(docs, query, fields = ['summary', 'tags', 'body']) {
+  if (!docs || docs.length === 0) {
+    return [];
+  }
+
+  const words = query.toLowerCase().split(/\s+/).filter(w => w.length > 0);
+
+  const results = docs.map(doc => {
+    // 검색 대상 텍스트 생성
+    const searchText = fields.map(field => {
+      let value = doc[field];
+      if (Array.isArray(value)) {
+        value = value.join(' ');
+      }
+      return value || '';
+    }).join(' ').toLowerCase();
+
+    // 매칭 단어 수 계산
+    const matchCount = words.filter(word => searchText.includes(word)).length;
+
+    return { ...doc, _score: matchCount };
+  })
+  .filter(item => item._score > 0)
+  .sort((a, b) => b._score - a._score);
+
+  return results;
+}
+
+module.exports = {
+  createSearchEngine,
+  search,
+  koreanKeywordSearch
+};

--- a/skills/lib/mindmap.js
+++ b/skills/lib/mindmap.js
@@ -1,0 +1,542 @@
+/**
+ * 마인드맵 공용 모듈
+ *
+ * memory-v2의 마인드맵 로직을 범용적으로 사용할 수 있도록 추출한 모듈
+ *
+ * Usage:
+ *   const { buildGraph, generateHtml } = require('./mindmap.js');
+ *
+ *   // 그래프 빌드
+ *   const graph = buildGraph('./entries', {
+ *     edgeThreshold: 0.3,
+ *     onProgress: (current, total) => console.log(`${current}/${total}`)
+ *   });
+ *
+ *   // HTML 생성
+ *   const html = generateHtml({ agentId: graph });
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+/**
+ * 마크다운 폴더에서 모든 엔트리 로드
+ * @param {String} entriesDir - 마크다운 파일이 있는 디렉토리
+ * @returns {Array} 파싱된 엔트리 배열
+ */
+function loadAllEntries(entriesDir) {
+  if (!fs.existsSync(entriesDir)) return [];
+
+  const files = fs.readdirSync(entriesDir).filter(f => f.endsWith('.md'));
+  const entries = [];
+
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(entriesDir, file), 'utf-8');
+    const { data, content } = matter(raw);
+    entries.push({ file, content, ...data });
+  }
+
+  return entries;
+}
+
+/**
+ * 두 엔트리 간 유사도 계산 (규칙 기반)
+ * @param {Object} entry1 - 첫 번째 엔트리
+ * @param {Object} entry2 - 두 번째 엔트리
+ * @param {Object} options - 옵션
+ * @param {Boolean} options.includeSameDay - same-day 연결 포함 여부 (기본: false)
+ * @returns {Array} 연결 엣지 배열 (type, weight 포함)
+ */
+function calculateSimilarity(entry1, entry2, options = {}) {
+  const { includeSameDay = false } = options;
+  const edges = [];
+
+  // 1. 같은 topic → 강한 연결
+  if (entry1.topic && entry1.topic === entry2.topic && entry1.topic !== 'general') {
+    edges.push({ type: 'same-topic', weight: 0.7 });
+  }
+
+  // 2. 공통 tags → 중간 연결 (가중치 상향)
+  const tags1 = new Set(entry1.tags || []);
+  const tags2 = new Set(entry2.tags || []);
+  const commonTags = [...tags1].filter(t => tags2.has(t));
+
+  if (commonTags.length > 0) {
+    // 공통 태그 수에 따라 가중치 증가 (1개=0.4, 2개=0.6, 3개+=0.8)
+    const weight = Math.min(0.4 + (commonTags.length - 1) * 0.2, 0.8);
+    edges.push({ type: 'shared-tags', weight, tags: commonTags });
+  }
+
+  // 3. 같은 날짜 → 약한 연결 (옵션으로 제어, 기본 OFF)
+  if (includeSameDay && entry1.date === entry2.date) {
+    edges.push({ type: 'same-day', weight: 0.3 });
+  }
+
+  // 4. 같은 카테고리 → 약한 연결
+  if (entry1.category && entry1.category === entry2.category && entry1.category !== 'general') {
+    edges.push({ type: 'same-category', weight: 0.2 });
+  }
+
+  return edges;
+}
+
+/**
+ * 마크다운 폴더에서 그래프 빌드
+ * @param {String} entriesDir - 마크다운 파일이 있는 디렉토리
+ * @param {Object} options - 빌드 옵션
+ * @param {Number} options.edgeThreshold - 엣지 저장 최소 weight (기본: 0.3)
+ * @param {Boolean} options.includeSameDay - same-day 연결 포함 여부 (기본: false)
+ * @param {Function} options.onProgress - 진행 콜백 (current, total)
+ * @param {Function} options.calculateSimilarity - 커스텀 유사도 계산 함수
+ * @returns {Object|null} { nodes, edges, stats } 또는 null (엔트리 없음)
+ */
+function buildGraph(entriesDir, options = {}) {
+  const {
+    edgeThreshold = 0.3,
+    includeSameDay = false,
+    onProgress = null,
+    calculateSimilarity: customSimilarity = null
+  } = options;
+
+  const entries = loadAllEntries(entriesDir);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const nodes = entries.map(e => ({
+    id: e.id,
+    summary: e.summary,
+    topic: e.topic,
+    date: e.date,
+    tags: e.tags || []
+  }));
+
+  const edges = [];
+  const similarityOpts = { includeSameDay };
+
+  // 모든 쌍 비교 (O(n^2) but memory count is usually small)
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const similarities = customSimilarity
+        ? customSimilarity(entries[i], entries[j])
+        : calculateSimilarity(entries[i], entries[j], similarityOpts);
+
+      if (similarities.length > 0) {
+        // 가장 강한 연결만 저장
+        const strongest = similarities.reduce((a, b) => a.weight > b.weight ? a : b);
+        const totalWeight = similarities.reduce((sum, s) => sum + s.weight, 0);
+
+        if (totalWeight >= edgeThreshold) {
+          edges.push({
+            from: entries[i].id,
+            to: entries[j].id,
+            type: strongest.type,
+            weight: Math.round(totalWeight * 100) / 100,
+            reasons: similarities.map(s => s.type)
+          });
+        }
+      }
+    }
+
+    // 진행 콜백 호출
+    if (onProgress) {
+      onProgress(i + 1, entries.length);
+    }
+  }
+
+  const graph = {
+    nodes,
+    edges,
+    stats: {
+      nodeCount: nodes.length,
+      edgeCount: edges.length
+    },
+    updated: new Date().toISOString()
+  };
+
+  return graph;
+}
+
+/**
+ * 여러 에이전트의 그래프를 받아 시각화 HTML 생성
+ * @param {Object} graphs - { agentId: graph } 형태의 객체
+ * @param {Object} options - HTML 생성 옵션
+ * @param {Array} options.colors - 토픽별 색상 팔레트
+ * @param {String} options.title - HTML 제목 (기본: 'Memory Mindmap')
+ * @returns {String} HTML 문자열
+ */
+function generateHtml(graphs, options = {}) {
+  const {
+    colors = [
+      '#6366f1', '#8b5cf6', '#ec4899', '#f43f5e', '#f97316',
+      '#eab308', '#22c55e', '#14b8a6', '#06b6d4', '#3b82f6'
+    ],
+    title = 'Memory Mindmap'
+  } = options;
+
+  if (Object.keys(graphs).length === 0) {
+    return null;
+  }
+
+  let totalNodes = 0;
+  let totalEdges = 0;
+
+  // 각 에이전트별 그래프 데이터 변환
+  const agentData = {};
+  for (const [agentId, graph] of Object.entries(graphs)) {
+    if (!graph || !graph.nodes || graph.nodes.length === 0) {
+      continue;
+    }
+
+    totalNodes += graph.nodes.length;
+    totalEdges += graph.edges.length;
+
+    const topics = [...new Set(graph.nodes.map(n => n.topic || 'general'))];
+    const topicColors = {};
+    topics.forEach((topic, i) => {
+      topicColors[topic] = colors[i % colors.length];
+    });
+
+    const nodes = graph.nodes.map(n => {
+      const summary = n.summary ? String(n.summary) : (n.id ? String(n.id) : 'Unknown');
+      return {
+        id: n.id || 'unknown',
+        label: summary.slice(0, 40),
+        fullLabel: summary,
+        topic: n.topic || 'general',
+        date: n.date || '-',
+        color: topicColors[n.topic || 'general']
+      };
+    });
+
+    const links = graph.edges.map(e => ({
+      source: e.from,
+      target: e.to,
+      weight: e.weight,
+      type: e.type
+    }));
+
+    agentData[agentId] = {
+      nodes,
+      links,
+      topics,
+      topicColors,
+      updated: graph.updated
+    };
+  }
+
+  const agentOptions = Object.keys(agentData).map(agentId =>
+    `<option value="${agentId}">${agentId}</option>`
+  ).join('');
+
+  const htmlContent = `<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      overflow: hidden;
+    }
+    #graph { width: 100vw; height: 100vh; }
+    .node circle {
+      cursor: pointer;
+      stroke: #fff;
+      stroke-width: 1.5px;
+      transition: all 0.2s;
+    }
+    .node circle:hover {
+      stroke-width: 3px;
+      filter: brightness(1.2);
+    }
+    .node text {
+      font-size: 10px;
+      fill: #e0e0e0;
+      pointer-events: none;
+      text-shadow: 0 0 3px #1a1a2e;
+    }
+    .link {
+      stroke: #4a4a6a;
+      stroke-opacity: 0.6;
+    }
+    .tooltip {
+      position: absolute;
+      background: #2d2d44;
+      border: 1px solid #4a4a6a;
+      border-radius: 8px;
+      padding: 12px;
+      color: #fff;
+      font-size: 13px;
+      max-width: 300px;
+      pointer-events: none;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+      z-index: 10;
+    }
+    .tooltip .title { font-weight: bold; margin-bottom: 8px; color: #a5b4fc; }
+    .tooltip .meta { color: #9ca3af; font-size: 11px; }
+    .controls {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      background: #2d2d44;
+      border-radius: 8px;
+      padding: 15px;
+      color: #fff;
+      font-size: 13px;
+      min-width: 200px;
+      z-index: 5;
+    }
+    .controls h3 { margin-bottom: 10px; color: #a5b4fc; }
+    .controls select {
+      width: 100%;
+      padding: 8px;
+      background: #1a1a2e;
+      color: #fff;
+      border: 1px solid #4a4a6a;
+      border-radius: 4px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .controls select:hover {
+      border-color: #6366f1;
+    }
+    .legend {
+      position: absolute;
+      top: 100px;
+      left: 20px;
+      background: #2d2d44;
+      border-radius: 8px;
+      padding: 15px;
+      color: #fff;
+      font-size: 12px;
+      max-height: calc(100vh - 200px);
+      overflow-y: auto;
+      z-index: 5;
+    }
+    .legend h4 { margin-bottom: 8px; color: #a5b4fc; font-size: 11px; }
+    .legend-item { display: flex; align-items: center; margin: 4px 0; }
+    .legend-color { width: 12px; height: 12px; border-radius: 50%; margin-right: 8px; flex-shrink: 0; }
+    .stats {
+      position: absolute;
+      bottom: 20px;
+      left: 20px;
+      background: #2d2d44;
+      border-radius: 8px;
+      padding: 10px 15px;
+      color: #9ca3af;
+      font-size: 11px;
+      z-index: 5;
+    }
+  </style>
+</head>
+<body>
+  <div id="graph"></div>
+
+  <div class="controls">
+    <h3>📊 ${title}</h3>
+    <select id="agentSelect">${agentOptions}</select>
+  </div>
+
+  <div class="legend" id="legend"></div>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="tooltip" style="display:none"></div>
+
+  <script>
+    const agentData = ${JSON.stringify(agentData)};
+
+    // URL 파라미터에서 agent 읽기 (?agent=cto)
+    const urlParams = new URLSearchParams(window.location.search);
+    const agentFromUrl = urlParams.get('agent');
+    let currentAgent = (agentFromUrl && agentData[agentFromUrl]) ? agentFromUrl : Object.keys(agentData)[0];
+
+    let simulation = null;
+    let svg = null;
+    let g = null;
+
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    function initSVG() {
+      svg = d3.select('#graph')
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height);
+
+      g = svg.append('g');
+
+      svg.call(d3.zoom()
+        .extent([[0, 0], [width, height]])
+        .scaleExtent([0.1, 4])
+        .on('zoom', (event) => g.attr('transform', event.transform)));
+    }
+
+    function updateLegend() {
+      const data = agentData[currentAgent];
+      const items = data.topics.map(t =>
+        '<div class="legend-item"><div class="legend-color" style="background:' + data.topicColors[t] + '"></div><span>' + t + '</span></div>'
+      ).join('');
+      document.getElementById('legend').innerHTML = '<h4>토픽</h4>' + items;
+    }
+
+    function updateStats() {
+      const data = agentData[currentAgent];
+      document.getElementById('stats').innerHTML =
+        '에이전트: ' + currentAgent + ' | ' +
+        '노드: ' + data.nodes.length + ' | ' +
+        '엣지: ' + data.links.length + ' | ' +
+        '업데이트: ' + (data.updated ? data.updated.slice(0, 10) : '-');
+    }
+
+    function renderGraph() {
+      const data = agentData[currentAgent];
+
+      if (simulation) {
+        simulation.stop();
+      }
+
+      g.selectAll('*').remove();
+
+      const nodes = JSON.parse(JSON.stringify(data.nodes));
+      const links = JSON.parse(JSON.stringify(data.links));
+
+      simulation = d3.forceSimulation(nodes)
+        .force('link', d3.forceLink(links).id(d => d.id).distance(80))
+        .force('charge', d3.forceManyBody().strength(-200))
+        .force('center', d3.forceCenter(width / 2, height / 2))
+        .force('collision', d3.forceCollide().radius(30));
+
+      const link = g.append('g')
+        .selectAll('line')
+        .data(links)
+        .join('line')
+        .attr('class', 'link')
+        .attr('stroke-width', d => Math.sqrt(d.weight) * 2);
+
+      const node = g.append('g')
+        .selectAll('g')
+        .data(nodes)
+        .join('g')
+        .attr('class', 'node')
+        .call(d3.drag()
+          .on('start', dragstarted)
+          .on('drag', dragged)
+          .on('end', dragended));
+
+      node.append('circle')
+        .attr('r', d => {
+          const connections = links.filter(l => l.source.id === d.id || l.target.id === d.id).length;
+          return Math.max(6, Math.min(20, 6 + connections));
+        })
+        .attr('fill', d => d.color);
+
+      node.append('text')
+        .attr('dx', 15)
+        .attr('dy', 4)
+        .text(d => d.label);
+
+      const tooltip = d3.select('.tooltip');
+
+      node.on('mouseover', (event, d) => {
+        tooltip.style('display', 'block')
+          .style('left', (event.pageX + 15) + 'px')
+          .style('top', (event.pageY - 10) + 'px')
+          .html('<div class="title">' + d.fullLabel + '</div><div class="meta">ID: ' + d.id + '<br>토픽: ' + d.topic + '<br>날짜: ' + d.date + '</div>');
+      }).on('mouseout', () => {
+        tooltip.style('display', 'none');
+      });
+
+      simulation.on('tick', () => {
+        link
+          .attr('x1', d => d.source.x)
+          .attr('y1', d => d.source.y)
+          .attr('x2', d => d.target.x)
+          .attr('y2', d => d.target.y);
+        node.attr('transform', d => 'translate(' + d.x + ',' + d.y + ')');
+      });
+
+      function dragstarted(event) {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        event.subject.fx = event.subject.x;
+        event.subject.fy = event.subject.y;
+      }
+
+      function dragged(event) {
+        event.subject.fx = event.x;
+        event.subject.fy = event.y;
+      }
+
+      function dragended(event) {
+        if (!event.active) simulation.alphaTarget(0);
+        event.subject.fx = null;
+        event.subject.fy = null;
+      }
+
+      updateLegend();
+      updateStats();
+    }
+
+    // DOM 준비 후 모든 초기화 수행
+    document.addEventListener('DOMContentLoaded', () => {
+      // 드롭다운 동기화
+      document.getElementById('agentSelect').value = currentAgent;
+
+      // 드롭다운 변경 이벤트
+      document.getElementById('agentSelect').addEventListener('change', (e) => {
+        currentAgent = e.target.value;
+        // URL 파라미터 업데이트
+        const url = new URL(window.location);
+        url.searchParams.set('agent', currentAgent);
+        history.replaceState({}, '', url);
+        renderGraph();
+      });
+
+      // 그래프 초기화 및 렌더링
+      initSVG();
+      renderGraph();
+    });
+  </script>
+</body>
+</html>`;
+
+  return htmlContent;
+}
+
+/**
+ * 그래프를 JSON 파일로 저장
+ * @param {String} outputPath - 저장할 파일 경로
+ * @param {Object} graph - 저장할 그래프
+ */
+function saveGraph(outputPath, graph) {
+  graph.updated = new Date().toISOString();
+  fs.writeFileSync(outputPath, JSON.stringify(graph, null, 2), 'utf-8');
+}
+
+/**
+ * JSON 파일에서 그래프 로드
+ * @param {String} inputPath - 로드할 파일 경로
+ * @returns {Object} { nodes, edges, stats, updated }
+ */
+function loadGraph(inputPath) {
+  if (!fs.existsSync(inputPath)) {
+    return { nodes: [], edges: [], stats: {}, updated: null };
+  }
+  return JSON.parse(fs.readFileSync(inputPath, 'utf-8'));
+}
+
+module.exports = {
+  loadAllEntries,
+  calculateSimilarity,
+  buildGraph,
+  generateHtml,
+  saveGraph,
+  loadGraph
+};

--- a/skills/lib/package.json
+++ b/skills/lib/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "memory-v2",
+  "name": "lib",
   "version": "1.0.0",
-  "main": "memory-v2.js",
+  "main": "skill-tracer.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,9 +10,9 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "gray-matter": "^4.0.3",
-    "nanoid": "^3.3.11",
+    "better-sqlite3": "^12.6.2",
     "wink-bm25-text-search": "^3.1.2",
-    "wink-nlp-utils": "^2.1.0"
+    "wink-nlp-utils": "^2.1.0",
+    "gray-matter": "^4.0.3"
   }
 }

--- a/skills/lib/skill-tracer.js
+++ b/skills/lib/skill-tracer.js
@@ -1,0 +1,282 @@
+/**
+ * skill-tracer.js - 스킬 실행 추적 라이브러리 (PoC)
+ *
+ * 스킬에서 직접 node skill.js 실행해도 로깅됨
+ * - usage.log: 텍스트 파일 로그 (경량)
+ * - traces.db: SQLite DB 로그 (상세)
+ */
+
+const Database = require('better-sqlite3');
+const path = require('path');
+const fs = require('fs');
+const { randomUUID } = require('crypto');
+
+/**
+ * traces.db 경로 찾기
+ */
+function getTracesDbPath() {
+  if (process.env.CREWX_TRACES_DB) {
+    return process.env.CREWX_TRACES_DB;
+  }
+
+  const localDb = path.join(process.cwd(), '.crewx', 'traces.db');
+  if (fs.existsSync(localDb)) {
+    return localDb;
+  }
+
+  const homeDb = path.join(process.env.HOME || '~', '.crewx', 'traces.db');
+  return homeDb;
+}
+
+/**
+ * traces.db 연결 및 테이블 확인
+ */
+function getDb() {
+  const dbPath = getTracesDbPath();
+  const dir = path.dirname(dbPath);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      user_id TEXT,
+      prompt TEXT NOT NULL,
+      mode TEXT NOT NULL DEFAULT 'execute',
+      status TEXT NOT NULL DEFAULT 'running',
+      result TEXT,
+      error TEXT,
+      started_at TEXT NOT NULL,
+      completed_at TEXT,
+      duration_ms INTEGER,
+      metadata TEXT
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS spans (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      parent_span_id TEXT,
+      name TEXT NOT NULL,
+      kind TEXT NOT NULL DEFAULT 'internal',
+      status TEXT NOT NULL DEFAULT 'ok',
+      started_at TEXT NOT NULL,
+      completed_at TEXT,
+      duration_ms INTEGER,
+      input TEXT,
+      output TEXT,
+      error TEXT,
+      attributes TEXT,
+      FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (parent_span_id) REFERENCES spans(id) ON DELETE SET NULL
+    )
+  `);
+
+  return db;
+}
+
+/**
+ * 로컬 타임스탬프 (usage.log용)
+ */
+function getLocalTimestamp() {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  const h = String(now.getHours()).padStart(2, '0');
+  const min = String(now.getMinutes()).padStart(2, '0');
+  const s = String(now.getSeconds()).padStart(2, '0');
+  return `${y}-${m}-${d} ${h}:${min}:${s}`;
+}
+
+/**
+ * usage.log에 기록
+ */
+function logToUsageFile(logPath, skillName, command) {
+  const timestamp = getLocalTimestamp();
+  const line = `${timestamp} | [${skillName}] ${command}\n`;
+  fs.appendFileSync(logPath, line);
+}
+
+/**
+ * 스킬 실행 추적 시작
+ *
+ * @param {string} skillName - 스킬 이름 (예: 'memory-v2')
+ * @param {string} command - 실행 명령어 (예: 'save agent1 test')
+ * @param {object} [options] - 옵션
+ * @param {string} [options.agentId] - 에이전트 ID
+ * @param {string} [options.usageLog] - usage.log 파일 경로 (지정하면 파일 로그도 남김)
+ * @param {boolean} [options.tracesDb=true] - traces.db 기록 여부
+ * @returns {{ taskId: string, ok: (result?: string) => void, fail: (error: string) => void }}
+ */
+function trace(skillName, command, options = {}) {
+  const {
+    agentId,
+    usageLog,
+    tracesDb = true
+  } = typeof options === 'string' ? { agentId: options } : options;
+
+  // usage.log 기록 (항상, 중복 상관없이)
+  if (usageLog) {
+    logToUsageFile(usageLog, skillName, command);
+  }
+
+  // traces.db 기록 비활성화된 경우
+  if (!tracesDb) {
+    return {
+      taskId: 'no-trace',
+      ok: () => {},
+      fail: () => {},
+      _skipped: true
+    };
+  }
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const resolvedAgentId = agentId || process.env.CREWX_AGENT_ID || 'direct';
+
+  // crewx skill x로 실행된 경우 → spans 테이블에 child span으로 기록
+  const parentTaskId = process.env.CREWX_TASK_ID;
+  if (parentTaskId && parentTaskId.trim() !== '') {
+    const spanId = randomUUID();
+    const attributes = JSON.stringify({
+      skill: skillName,
+      agent_id: resolvedAgentId,
+      tracer_version: '0.3.0'
+    });
+
+    // Ensure parent task record exists (stub for crewx-managed tasks)
+    db.prepare(`
+      INSERT OR IGNORE INTO tasks (id, agent_id, prompt, mode, status, started_at)
+      VALUES (?, ?, ?, 'execute', 'running', ?)
+    `).run(parentTaskId, resolvedAgentId, `[crewx-task] ${parentTaskId}`, now);
+
+    db.prepare(`
+      INSERT INTO spans (id, task_id, name, kind, status, started_at, input, attributes)
+      VALUES (?, ?, ?, 'internal', 'ok', ?, ?, ?)
+    `).run(spanId, parentTaskId, `[skill:${skillName}] ${command}`, now, command, attributes);
+
+    return {
+      taskId: parentTaskId,
+      spanId,
+      ok: (result) => {
+        const completedAt = new Date().toISOString();
+        db.prepare(`
+          UPDATE spans
+          SET status = 'ok',
+              output = ?,
+              completed_at = ?,
+              duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER)
+          WHERE id = ?
+        `).run(result || null, completedAt, completedAt, spanId);
+        db.close();
+      },
+      fail: (error) => {
+        const completedAt = new Date().toISOString();
+        db.prepare(`
+          UPDATE spans
+          SET status = 'error',
+              error = ?,
+              completed_at = ?,
+              duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER)
+          WHERE id = ?
+        `).run(error, completedAt, completedAt, spanId);
+        db.close();
+      },
+      _skipped: false
+    };
+  }
+
+  // 직접 호출 (독립 실행) → 기존대로 tasks 테이블에 기록
+  const taskId = randomUUID();
+  const metadata = JSON.stringify({
+    skill: skillName,
+    direct_call: true,
+    tracer_version: '0.3.0'
+  });
+
+  db.prepare(`
+    INSERT INTO tasks (id, agent_id, prompt, mode, status, started_at, metadata)
+    VALUES (?, ?, ?, 'execute', 'running', ?, ?)
+  `).run(taskId, resolvedAgentId, `[skill:${skillName}] ${command}`, now, metadata);
+
+  return {
+    taskId,
+    ok: (result) => {
+      const completedAt = new Date().toISOString();
+      db.prepare(`
+        UPDATE tasks
+        SET status = 'success',
+            result = ?,
+            completed_at = ?,
+            duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER)
+        WHERE id = ?
+      `).run(result || null, completedAt, completedAt, taskId);
+      db.close();
+    },
+    fail: (error) => {
+      const completedAt = new Date().toISOString();
+      db.prepare(`
+        UPDATE tasks
+        SET status = 'failed',
+            error = ?,
+            completed_at = ?,
+            duration_ms = CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER)
+        WHERE id = ?
+      `).run(error, completedAt, completedAt, taskId);
+      db.close();
+    },
+    _skipped: false
+  };
+}
+
+/**
+ * 스킬 실행 래퍼 (권장)
+ * try/catch, trace 시작/종료 자동 처리
+ *
+ * @param {string} skillName - 스킬 이름
+ * @param {() => Promise<any>} fn - 실행할 함수
+ * @param {object} [options] - 옵션
+ * @param {string} [options.usageLog] - usage.log 파일 경로
+ * @param {boolean} [options.tracesDb=true] - traces.db 기록 여부
+ * @returns {Promise<any>}
+ *
+ * @example
+ * // 둘 다 기록
+ * run('memory-v2', main, {
+ *   usageLog: path.join(__dirname, 'usage.log'),
+ *   tracesDb: true
+ * });
+ *
+ * // usage.log만
+ * run('memory-v2', main, {
+ *   usageLog: path.join(__dirname, 'usage.log'),
+ *   tracesDb: false
+ * });
+ *
+ * // traces.db만 (기본)
+ * run('memory-v2', main);
+ */
+async function run(skillName, fn, options = {}) {
+  const command = process.argv.slice(2).join(' ');
+  const t = trace(skillName, command, options);
+
+  try {
+    const result = await fn();
+    const resultStr = result !== undefined ? JSON.stringify(result) : null;
+    t.ok(resultStr);
+    return result;
+  } catch (e) {
+    t.fail(e.message || String(e));
+    throw e;
+  }
+}
+
+module.exports = { trace, run, getTracesDbPath };

--- a/skills/memory-v2/SKILL.md
+++ b/skills/memory-v2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memory-v2
 description: 마크다운 + 프론트매터 기반 장기 기억 스킬. 드릴다운 구조로 확장성 있는 기억 관리.
-version: 0.4.1
+version: 0.7.0
 ---
 
 # Memory V2 Skill
@@ -272,6 +272,140 @@ node skills/memory-v2/memory-v2.js save {{agent_id}} "<요약>" <category> --top
 | 조회 | 전체 로드 | 인덱스 → 드릴다운 |
 | 토픽 지원 | 없음 | 있음 |
 | 가독성 | 낮음 | 높음 |
+
+## 마인드맵 (기억 연결 그래프)
+
+기억 간 연관성을 그래프로 관리합니다.
+
+### 그래프 빌드
+
+```bash
+node skills/memory-v2/mindmap.js build <agent_id>
+```
+
+규칙 기반으로 연결 생성:
+- **같은 topic**: weight 0.7 (⚠️ `general` 제외)
+- **공통 tags**: weight 0.4~0.8 (1개=0.4, 2개=0.6, 3개+=0.8)
+- **같은 날짜**: weight 0.3 (기본 OFF)
+- **같은 category**: weight 0.2 (⚠️ `general` 제외)
+
+> **edgeThreshold = 0.3** → 총 weight가 0.3 이상이어야 연결됨
+
+### ⭐ 연결성 높이는 저장 팁
+
+**핵심: `general`을 피하고 구체적으로!**
+
+| 방법 | Weight | 효과 |
+|------|--------|------|
+| topic 지정 | +0.7 | 같은 토픽 기억들 자동 연결 |
+| 태그 2개+ | +0.6 | 토픽 달라도 태그로 연결 |
+| 태그 3개+ | +0.8 | 최대 연결 강도 |
+| category | +0.2 | decision/task 등 구체적으로 |
+
+**❌ 나쁜 예 (연결 안 됨)**
+```bash
+# topic=general, category=general → 연결 0
+node memory-v2.js save agent "Discord 설정 제거" general
+```
+
+**✅ 좋은 예 (강한 연결)**
+```bash
+# topic + category + tags → 최대 연결
+node memory-v2.js save agent "Discord 설정 제거 결정" decision \
+  --topic=discord \
+  --tags=settings,cpo-decision,oauth \
+  --body="CPO 회의 결과..."
+```
+
+**태그 활용 전략:**
+- 관련 기능/모듈명: `discord`, `oauth`, `settings`
+- 회의/결정자: `cpo-decision`, `dev-meeting`
+- 상태: `completed`, `blocked`, `wip`
+
+### 마인드맵 요약 보기
+
+```bash
+node skills/memory-v2/mindmap.js show <agent_id>
+```
+
+토픽별 클러스터, 허브 노드(연결 많은 기억) 등 표시.
+
+### 연결된 기억 조회
+
+```bash
+node skills/memory-v2/mindmap.js related <agent_id> <memory_id>
+```
+
+특정 기억과 연결된 기억들을 weight 순으로 표시.
+
+### 수동 연결 관리
+
+```bash
+# 연결 추가
+node skills/memory-v2/mindmap.js add <agent_id> <from_id> <to_id> [type]
+
+# 연결 제거
+node skills/memory-v2/mindmap.js remove <agent_id> <from_id> <to_id>
+```
+
+### 시각화 (HTML) - 공용 마인드맵
+
+```bash
+node skills/memory-v2/mindmap.js html
+```
+
+**모든 에이전트의 마인드맵을 한 곳에 통합한 공용 시각화**를 생성합니다.
+
+**특징:**
+- 모든 에이전트의 graph.json 데이터를 하나의 HTML에 임베드
+- 드롭다운으로 에이전트 선택 → 해당 그래프로 실시간 전환
+- D3.js force-directed 그래프
+- 토픽별 색상 구분
+- 줌 & 드래그 지원
+- 호버 시 상세 정보 툴팁
+- 노드 크기 = 연결 수
+- 서버 없이 file:// 프로토콜로 바로 열기 가능
+
+**사용법:**
+```bash
+# 1. 공용 HTML 생성 (agent_id 필요 없음)
+node skills/memory-v2/mindmap.js html
+
+# 2. 브라우저에서 열기
+open skills/memory-v2/mindmap.html
+```
+
+**예시:**
+```bash
+# 전체 에이전트 마인드맵 통합 시각화
+node skills/memory-v2/mindmap.js html
+```
+
+### 브라우저에서 열기
+
+```bash
+node skills/memory-v2/mindmap.js open [agent_id]
+```
+
+특정 에이전트의 마인드맵을 브라우저에서 바로 엽니다.
+
+**예시:**
+```bash
+# CTO 마인드맵 열기
+node skills/memory-v2/mindmap.js open cto
+
+# 전체 (기본 에이전트) 열기
+node skills/memory-v2/mindmap.js open
+```
+
+### 저장 위치
+
+```
+data/{agent_id}/graph.json           # 그래프 데이터
+skills/memory-v2/mindmap.html        # 공용 시각화 HTML
+```
+
+---
 
 ## v1 → v2 마이그레이션
 

--- a/skills/memory-v2/crewx.yaml
+++ b/skills/memory-v2/crewx.yaml
@@ -10,10 +10,10 @@ agents:
   - id: "memory_searcher"
     name: "Memory Searcher"
     role: "searcher"
-    description: "Semantic search agent for memory entries using Gemini Flash"
-    provider: "cli/gemini"
+    description: "Semantic search agent for memory entries using Haiku"
+    provider: "cli/claude"
     inline:
-      model: "flash"
+      model: "haiku"
       layout: "crewx/minimal"
       prompt: |
         You are a Memory Searcher Agent. Your job is to find relevant memories from the provided memory list.

--- a/skills/memory-v2/memory-v2.js
+++ b/skills/memory-v2/memory-v2.js
@@ -21,6 +21,9 @@ const path = require('path');
 const matter = require('gray-matter');
 const { nanoid } = require('nanoid');
 const { execSync } = require('child_process');
+const { search: bm25Search, koreanKeywordSearch } = require('../lib/bm25-search');
+const { buildGraph } = require('./mindmap');
+const { run } = require('../lib/skill-tracer');
 
 const DATA_DIR = path.join(__dirname, 'data');
 const USAGE_LOG = path.join(__dirname, 'usage.log');
@@ -72,26 +75,26 @@ function getToday() {
   return new Date().toISOString().slice(0, 10);
 }
 
-function getLocalTimestamp() {
+// getLocalTimestamp() 제거됨 - skill-tracer로 통합
+
+function getLocalISO8601() {
   const now = new Date();
+  const offset = -now.getTimezoneOffset();
+  const sign = offset >= 0 ? '+' : '-';
+  const offsetHours = String(Math.floor(Math.abs(offset) / 60)).padStart(2, '0');
+  const offsetMins = String(Math.abs(offset) % 60).padStart(2, '0');
+
   const y = now.getFullYear();
   const m = String(now.getMonth() + 1).padStart(2, '0');
   const d = String(now.getDate()).padStart(2, '0');
   const h = String(now.getHours()).padStart(2, '0');
   const min = String(now.getMinutes()).padStart(2, '0');
   const s = String(now.getSeconds()).padStart(2, '0');
-  return `${y}-${m}-${d} ${h}:${min}:${s}`;
+
+  return `${y}-${m}-${d}T${h}:${min}:${s}${sign}${offsetHours}:${offsetMins}`;
 }
 
-function logUsage(cmd, agentId, extra) {
-  try {
-    const timestamp = getLocalTimestamp();
-    const logLine = `${timestamp} | [memory-v2] ${cmd} ${agentId || ''} ${extra || ''}\n`;
-    fs.appendFileSync(USAGE_LOG, logLine);
-  } catch (e) {
-    // Silently fail
-  }
-}
+// logUsage() 제거됨 - skill-tracer로 통합
 
 // ============ Frontmatter Parsing (using gray-matter) ============
 
@@ -124,8 +127,15 @@ function loadAllEntries(agentId) {
     entries.push({ file, hasBody, ...data });
   }
 
-  // Sort by date descending
-  entries.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+  // Sort by created_at descending (newest first)
+  const toTimestamp = e => {
+    if (e.created_at) return String(e.created_at);
+    // fallback to date if no created_at
+    const d = e.date;
+    const dateStr = d instanceof Date ? d.toISOString().slice(0, 10) : String(d || '');
+    return dateStr + 'T09:00:00+09:00';
+  };
+  entries.sort((a, b) => toTimestamp(b).localeCompare(toTimestamp(a)));
   return entries;
 }
 
@@ -241,6 +251,7 @@ function cmdSave(agentId, summary, category = 'general', options = {}) {
   const frontmatter = stringifyFrontmatter({
     id,
     date,
+    created_at: getLocalISO8601(),
     category,
     tags,
     topic,
@@ -260,6 +271,14 @@ function cmdSave(agentId, summary, category = 'general', options = {}) {
   console.log(`   ID: ${id}`);
   console.log(`   Topic: ${topic}`);
   console.log(`   Category: ${category}`);
+
+  // 마인드맵 자동 갱신 (빠름 ~100ms)
+  try {
+    buildGraph(agentId);
+    console.log(`   🔗 마인드맵 갱신됨`);
+  } catch (e) {
+    // 실패해도 저장은 완료됨
+  }
 }
 
 function cmdIndex(agentId) {
@@ -299,7 +318,11 @@ function cmdRecent(agentId, days = 30) {
   console.log(`## 🔥 최근 ${days}일 (${filtered.length}건)\n`);
   for (const entry of filtered) {
     const detailIcon = entry.hasBody ? ' 📄' : '';
-    console.log(`[${entry.id}] [${entry.date}] [${entry.category}] ${entry.summary}${detailIcon}`);
+    // created_at에서 날짜+시간 추출 (2026-02-03T14:30:00+09:00 → 2026-02-03 14:30)
+    const timestamp = entry.created_at
+      ? String(entry.created_at).slice(0, 16).replace('T', ' ')
+      : entry.date;
+    console.log(`[${entry.id}] [${timestamp}] [${entry.category}] ${entry.summary}${detailIcon}`);
   }
 }
 
@@ -311,18 +334,29 @@ function cmdFind(agentId, keyword) {
   }
 
   const files = fs.readdirSync(entriesDir).filter(f => f.endsWith('.md'));
-  const results = [];
-  const keywordLower = keyword.toLowerCase();
+  const entries = [];
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(entriesDir, file), 'utf-8');
-    const { data } = parseFrontmatter(content);
+    const { data, content: body } = parseFrontmatter(content);
+    entries.push({ file, body, ...data });
+  }
 
-    // Search in summary, tags, content
-    const searchText = `${data.summary || ''} ${(data.tags || []).join(' ')} ${content}`.toLowerCase();
-    if (searchText.includes(keywordLower)) {
-      results.push({ file, ...data });
-    }
+  if (entries.length === 0) {
+    console.log('기억이 없습니다.');
+    return;
+  }
+
+  // Check if query contains Korean (한글)
+  const hasKorean = /[가-힣]/.test(keyword);
+  let results = [];
+
+  if (hasKorean) {
+    // Korean keyword search
+    results = koreanKeywordSearch(entries, keyword, ['summary', 'tags', 'topic', 'body']);
+  } else {
+    // BM25 search for English
+    results = bm25Search(entries, keyword, { summary: 3, tags: 2, topic: 1, body: 1 });
   }
 
   if (results.length === 0) {
@@ -330,9 +364,10 @@ function cmdFind(agentId, keyword) {
     return;
   }
 
-  console.log(`## 🔍 검색 결과: "${keyword}" (${results.length}건)\n`);
+  console.log(`## 🔍 검색 결과: "${keyword}" (${results.length}건, BM25 점수순)\n`);
   for (const entry of results) {
-    console.log(`[${entry.id}] [${entry.date}] [${entry.topic}] ${entry.summary}`);
+    const score = entry._score ? ` [${entry._score}점]` : '';
+    console.log(`[${entry.id}] [${entry.date}] [${entry.topic}]${score} ${entry.summary}`);
   }
 }
 
@@ -359,6 +394,35 @@ function cmdGet(agentId, memoryId) {
       console.log(`- 파일: data/${agentId}/entries/${file}`);
       console.log(`\n---\n`);
       console.log(content.trim());
+
+      // 연관 기억 표시 (graph.json 있으면)
+      const graphPath = path.join(getAgentDir(agentId), 'graph.json');
+      if (fs.existsSync(graphPath)) {
+        try {
+          const graph = JSON.parse(fs.readFileSync(graphPath, 'utf-8'));
+          const relatedEdges = graph.edges
+            .filter(e => e.from === memoryId || e.to === memoryId)
+            .sort((a, b) => b.weight - a.weight)
+            .slice(0, 5);
+
+          if (relatedEdges.length > 0) {
+            const nodeMap = {};
+            graph.nodes.forEach(n => nodeMap[n.id] = n);
+
+            console.log(`\n---\n`);
+            console.log(`## 🔗 연관 기억 (${relatedEdges.length}개)\n`);
+            for (const edge of relatedEdges) {
+              const otherId = edge.from === memoryId ? edge.to : edge.from;
+              const other = nodeMap[otherId];
+              if (other) {
+                console.log(`[${edge.weight}] [${otherId}] ${other.summary.slice(0, 50)}...`);
+              }
+            }
+          }
+        } catch (e) {
+          // graph.json 파싱 실패 시 무시
+        }
+      }
       return;
     }
   }
@@ -425,6 +489,14 @@ function cmdDelete(agentId, memoryId, options = {}) {
   console.log(`🗑️  삭제 완료: ${entry.file}`);
   console.log(`   ID: ${memoryId}`);
   console.log(`   Summary: ${entry.data.summary}`);
+
+  // 마인드맵 자동 갱신
+  try {
+    buildGraph(agentId);
+    console.log(`   🔗 마인드맵 갱신됨`);
+  } catch (e) {
+    // 실패해도 삭제는 완료됨
+  }
 }
 
 function cmdMerge(agentId, memoryId1, memoryId2, options = {}) {
@@ -492,6 +564,14 @@ ${body2 !== '(상세 내용을 여기에 추가)' ? body2 : '(상세 없음)'}`;
   console.log(`   새 파일: ${filename}`);
   console.log(`   병합된 기억: [${memoryId1}] + [${memoryId2}]`);
   console.log(`   Summary: ${mergedSummary}`);
+
+  // 마인드맵 자동 갱신
+  try {
+    buildGraph(agentId);
+    console.log(`   🔗 마인드맵 갱신됨`);
+  } catch (e) {
+    // 실패해도 병합은 완료됨
+  }
 }
 
 function cmdSearch(agentId, query) {
@@ -562,9 +642,6 @@ function main() {
     console.log('Error: agent_id is required');
     process.exit(1);
   }
-
-  // Log usage
-  logUsage(command, agentId, rest.join(' '));
 
   switch (command) {
     case 'save':
@@ -648,4 +725,8 @@ function main() {
   }
 }
 
-main();
+// skill-tracer로 실행 추적 (직접 호출해도 로깅됨)
+run('memory-v2', main, {
+  usageLog: USAGE_LOG,  // usage.log 파일 로그
+  tracesDb: true        // traces.db 기록
+});

--- a/skills/memory-v2/mindmap.js
+++ b/skills/memory-v2/mindmap.js
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+
+/**
+ * Memory Mindmap - 기억 간 연결 그래프 관리
+ *
+ * Usage:
+ *   node mindmap.js build <agent_id>                    # 그래프 빌드 (규칙 기반)
+ *   node mindmap.js show <agent_id>                     # 그래프 요약 출력
+ *   node mindmap.js related <agent_id> <memory_id>      # 연결된 기억 조회
+ *   node mindmap.js add <agent_id> <from> <to> [type]   # 수동 연결 추가
+ *   node mindmap.js remove <agent_id> <from> <to>       # 연결 제거
+ *   node mindmap.js html                                # 공용 HTML 생성 (모든 에이전트)
+ *   node mindmap.js open [agent_id]                     # 브라우저에서 마인드맵 열기
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+const {
+  loadAllEntries: libLoadAllEntries,
+  calculateSimilarity: libCalculateSimilarity,
+  buildGraph: libBuildGraph,
+  generateHtml: libGenerateHtml,
+  saveGraph: libSaveGraph,
+  loadGraph: libLoadGraph
+} = require('../lib/mindmap');
+
+const DATA_DIR = path.join(__dirname, 'data');
+const USAGE_LOG = path.join(__dirname, 'usage.log');
+
+// ============ Usage Logging ============
+
+function getLocalTimestamp() {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mi = String(now.getMinutes()).padStart(2, '0');
+  const ss = String(now.getSeconds()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}`;
+}
+
+function logUsage(cmd, agentId, extra) {
+  try {
+    const timestamp = getLocalTimestamp();
+    const logLine = `${timestamp} | [mindmap] ${cmd} ${agentId || ''} ${extra || ''}\n`;
+    fs.appendFileSync(USAGE_LOG, logLine);
+  } catch (e) {
+    // Silently fail
+  }
+}
+
+// ============ Utilities ============
+
+function getAgentDir(agentId) {
+  return path.join(DATA_DIR, agentId);
+}
+
+function getEntriesDir(agentId) {
+  return path.join(getAgentDir(agentId), 'entries');
+}
+
+function getGraphPath(agentId) {
+  return path.join(getAgentDir(agentId), 'graph.json');
+}
+
+function parseArgs(args) {
+  const result = { positional: [], options: {} };
+  for (const arg of args) {
+    if (arg.startsWith('--')) {
+      const [key, value] = arg.slice(2).split('=');
+      result.options[key] = value || true;
+    } else {
+      result.positional.push(arg);
+    }
+  }
+  return result;
+}
+
+// memory-v2 특화: agentId로 entriesDir 경로 변환 후 lib 함수 호출
+function loadAllEntries(agentId) {
+  const entriesDir = getEntriesDir(agentId);
+  return libLoadAllEntries(entriesDir);
+}
+
+function loadGraph(agentId) {
+  const graphPath = getGraphPath(agentId);
+  return libLoadGraph(graphPath);
+}
+
+function saveGraph(agentId, graph) {
+  const graphPath = getGraphPath(agentId);
+  libSaveGraph(graphPath, graph);
+}
+
+// ============ Graph Building ============
+
+// lib의 calculateSimilarity 재사용
+const calculateSimilarity = libCalculateSimilarity;
+
+function buildGraph(agentId, options = {}) {
+  const entriesDir = getEntriesDir(agentId);
+
+  const graph = libBuildGraph(entriesDir, {
+    edgeThreshold: 0.3,
+    ...options
+  });
+
+  if (!graph) {
+    console.log('기억이 없습니다.');
+    return null;
+  }
+
+  // graph를 agentId 경로에 저장
+  saveGraph(agentId, graph);
+
+  return graph;
+}
+
+// ============ Commands ============
+
+function cmdBuild(agentId, options = {}) {
+  console.log(`🔨 ${agentId} 마인드맵 빌드 중...\n`);
+
+  const graph = buildGraph(agentId, options);
+
+  if (!graph) return;
+
+  console.log(`✅ 마인드맵 빌드 완료!`);
+  console.log(`   노드: ${graph.stats.nodeCount}개`);
+  console.log(`   엣지: ${graph.stats.edgeCount}개`);
+  console.log(`   파일: data/${agentId}/graph.json`);
+
+  // Top connections
+  if (graph.edges.length > 0) {
+    console.log(`\n📊 주요 연결 (weight 상위 10개):`);
+    const topEdges = graph.edges.sort((a, b) => b.weight - a.weight).slice(0, 10);
+
+    const nodeMap = {};
+    graph.nodes.forEach(n => nodeMap[n.id] = n.summary);
+
+    for (const edge of topEdges) {
+      const fromSummary = (nodeMap[edge.from] || edge.from).slice(0, 25);
+      const toSummary = (nodeMap[edge.to] || edge.to).slice(0, 25);
+      console.log(`   [${edge.weight}] ${fromSummary}... ↔ ${toSummary}...`);
+    }
+  }
+}
+
+function cmdShow(agentId) {
+  const graph = loadGraph(agentId);
+
+  if (!graph.nodes || graph.nodes.length === 0) {
+    console.log('마인드맵이 없습니다. 먼저 build 명령을 실행하세요.');
+    return;
+  }
+
+  console.log(`# ${agentId} 마인드맵\n`);
+  console.log(`> 최종 업데이트: ${graph.updated || '-'}`);
+  console.log(`> 노드: ${graph.nodes.length}개 | 엣지: ${graph.edges.length}개\n`);
+
+  // Topic clusters
+  const byTopic = {};
+  for (const node of graph.nodes) {
+    const topic = node.topic || 'general';
+    if (!byTopic[topic]) byTopic[topic] = [];
+    byTopic[topic].push(node);
+  }
+
+  console.log(`## 토픽별 클러스터\n`);
+  for (const [topic, nodes] of Object.entries(byTopic).sort((a, b) => b[1].length - a[1].length)) {
+    console.log(`### ${topic} (${nodes.length}개)`);
+    for (const node of nodes.slice(0, 5)) {
+      // Count connections for this node
+      const connectionCount = graph.edges.filter(e => e.from === node.id || e.to === node.id).length;
+      console.log(`- [${node.id}] ${node.summary} (연결: ${connectionCount})`);
+    }
+    if (nodes.length > 5) {
+      console.log(`- ... 외 ${nodes.length - 5}개`);
+    }
+    console.log('');
+  }
+
+  // Hub nodes (most connected)
+  const connectionCounts = {};
+  for (const edge of graph.edges) {
+    connectionCounts[edge.from] = (connectionCounts[edge.from] || 0) + 1;
+    connectionCounts[edge.to] = (connectionCounts[edge.to] || 0) + 1;
+  }
+
+  const hubs = Object.entries(connectionCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+
+  if (hubs.length > 0) {
+    console.log(`## 허브 노드 (연결 많은 기억)\n`);
+    const nodeMap = {};
+    graph.nodes.forEach(n => nodeMap[n.id] = n);
+
+    for (const [id, count] of hubs) {
+      const node = nodeMap[id];
+      if (node) {
+        console.log(`- [${id}] ${node.summary} - ${count}개 연결`);
+      }
+    }
+  }
+}
+
+function cmdRelated(agentId, memoryId) {
+  const graph = loadGraph(agentId);
+
+  if (!graph.nodes || graph.nodes.length === 0) {
+    console.log('마인드맵이 없습니다. 먼저 build 명령을 실행하세요.');
+    return;
+  }
+
+  const node = graph.nodes.find(n => n.id === memoryId);
+  if (!node) {
+    console.log(`ID '${memoryId}'를 찾을 수 없습니다.`);
+    return;
+  }
+
+  console.log(`## 🔗 [${memoryId}] ${node.summary}\n`);
+  console.log(`- 토픽: ${node.topic || '-'}`);
+  console.log(`- 날짜: ${node.date || '-'}`);
+  console.log(`- 태그: ${(node.tags || []).join(', ') || '-'}\n`);
+
+  // Find connected edges
+  const connectedEdges = graph.edges.filter(e => e.from === memoryId || e.to === memoryId);
+
+  if (connectedEdges.length === 0) {
+    console.log('연결된 기억이 없습니다.');
+    return;
+  }
+
+  console.log(`### 연결된 기억 (${connectedEdges.length}개)\n`);
+
+  const nodeMap = {};
+  graph.nodes.forEach(n => nodeMap[n.id] = n);
+
+  // Sort by weight
+  connectedEdges.sort((a, b) => b.weight - a.weight);
+
+  for (const edge of connectedEdges) {
+    const otherId = edge.from === memoryId ? edge.to : edge.from;
+    const otherNode = nodeMap[otherId];
+
+    if (otherNode) {
+      const reasons = edge.reasons.join(', ');
+      console.log(`[${edge.weight}] [${otherId}] ${otherNode.summary}`);
+      console.log(`    └─ 연결 이유: ${reasons}`);
+    }
+  }
+}
+
+function cmdAdd(agentId, fromId, toId, type = 'manual') {
+  const graph = loadGraph(agentId);
+
+  if (!graph.nodes || graph.nodes.length === 0) {
+    console.log('마인드맵이 없습니다. 먼저 build 명령을 실행하세요.');
+    return;
+  }
+
+  // Check if nodes exist
+  const fromNode = graph.nodes.find(n => n.id === fromId);
+  const toNode = graph.nodes.find(n => n.id === toId);
+
+  if (!fromNode) {
+    console.log(`ID '${fromId}'를 찾을 수 없습니다.`);
+    return;
+  }
+  if (!toNode) {
+    console.log(`ID '${toId}'를 찾을 수 없습니다.`);
+    return;
+  }
+
+  // Check if edge already exists
+  const existingEdge = graph.edges.find(e =>
+    (e.from === fromId && e.to === toId) || (e.from === toId && e.to === fromId)
+  );
+
+  if (existingEdge) {
+    console.log(`이미 연결되어 있습니다: weight ${existingEdge.weight}`);
+    return;
+  }
+
+  // Add edge
+  graph.edges.push({
+    from: fromId,
+    to: toId,
+    type: type,
+    weight: 1.0,
+    reasons: [type],
+    manual: true
+  });
+
+  saveGraph(agentId, graph);
+
+  console.log(`✅ 연결 추가 완료!`);
+  console.log(`   ${fromNode.summary.slice(0, 30)}...`);
+  console.log(`   ↔`);
+  console.log(`   ${toNode.summary.slice(0, 30)}...`);
+}
+
+function cmdRemove(agentId, fromId, toId) {
+  const graph = loadGraph(agentId);
+
+  if (!graph.edges || graph.edges.length === 0) {
+    console.log('연결이 없습니다.');
+    return;
+  }
+
+  const edgeIndex = graph.edges.findIndex(e =>
+    (e.from === fromId && e.to === toId) || (e.from === toId && e.to === fromId)
+  );
+
+  if (edgeIndex === -1) {
+    console.log('해당 연결을 찾을 수 없습니다.');
+    return;
+  }
+
+  graph.edges.splice(edgeIndex, 1);
+  saveGraph(agentId, graph);
+
+  console.log(`🗑️ 연결 제거 완료: ${fromId} ↔ ${toId}`);
+}
+
+function cmdOpen(agentId) {
+  const htmlPath = path.join(__dirname, 'mindmap.html');
+
+  if (!fs.existsSync(htmlPath)) {
+    console.log('mindmap.html이 없습니다. 먼저 html 명령을 실행하세요.');
+    return;
+  }
+
+  const url = `file://${htmlPath}${agentId ? '?agent=' + agentId : ''}`;
+
+  // macOS: Chrome으로 열기 (query param 유지)
+  const { execSync } = require('child_process');
+  try {
+    execSync(`osascript -e 'tell application "Google Chrome" to open location "${url}"'`);
+    console.log(`✅ Chrome에서 마인드맵 열기: ${agentId || '전체'}`);
+  } catch (e) {
+    // Chrome 없으면 Safari로 시도
+    try {
+      execSync(`osascript -e 'tell application "Safari" to open location "${url}"'`);
+      console.log(`✅ Safari에서 마인드맵 열기: ${agentId || '전체'}`);
+    } catch (e2) {
+      // 기본 open 명령
+      execSync(`open "${url}"`);
+      console.log(`✅ 기본 브라우저에서 마인드맵 열기: ${agentId || '전체'}`);
+    }
+  }
+}
+
+function cmdHtml() {
+  // 모든 에이전트의 graph.json 로드
+  if (!fs.existsSync(DATA_DIR)) {
+    console.log('data 디렉토리가 없습니다.');
+    return;
+  }
+
+  const agentDirs = fs.readdirSync(DATA_DIR).filter(name => {
+    const dirPath = path.join(DATA_DIR, name);
+    return fs.statSync(dirPath).isDirectory();
+  });
+
+  const agentGraphs = {};
+  let totalNodes = 0;
+  let totalEdges = 0;
+
+  for (const agentId of agentDirs) {
+    const graph = loadGraph(agentId);
+    if (graph.nodes && graph.nodes.length > 0) {
+      agentGraphs[agentId] = graph;
+      totalNodes += graph.nodes.length;
+      totalEdges += graph.edges.length;
+    }
+  }
+
+  if (Object.keys(agentGraphs).length === 0) {
+    console.log('마인드맵이 없습니다. 먼저 build 명령을 실행하세요.');
+    return;
+  }
+
+  // lib의 generateHtml 사용
+  const htmlContent = libGenerateHtml(agentGraphs, {
+    title: 'Memory Mindmap - All Agents'
+  });
+
+  if (!htmlContent) {
+    console.log('HTML 생성 실패');
+    return;
+  }
+
+  const htmlPath = path.join(__dirname, 'mindmap.html');
+  fs.writeFileSync(htmlPath, htmlContent, 'utf-8');
+
+  console.log(`✅ 공용 마인드맵 시각화 생성 완료!`);
+  console.log(`   파일: skills/memory-v2/mindmap.html`);
+  console.log(`   에이전트: ${Object.keys(agentGraphs).length}개`);
+  console.log(`   전체 노드: ${totalNodes}개 | 전체 엣지: ${totalEdges}개`);
+  console.log(`\n브라우저에서 열기: open ${htmlPath}`);
+}
+
+// ============ Main ============
+
+function main() {
+  const args = process.argv.slice(2);
+  const { positional, options } = parseArgs(args);
+  const [command, agentId, ...rest] = positional;
+
+  if (!command) {
+    console.log('Usage: node mindmap.js <command> [args]');
+    console.log('');
+    console.log('Commands:');
+    console.log('  build <agent_id>              - 마인드맵 빌드 (규칙 기반)');
+    console.log('  show <agent_id>               - 마인드맵 요약 출력');
+    console.log('  related <agent_id> <id>       - 연결된 기억 조회');
+    console.log('  add <agent_id> <from> <to>    - 수동 연결 추가');
+    console.log('  remove <agent_id> <from> <to> - 연결 제거');
+    console.log('  html                          - 공용 시각화 HTML 생성 (모든 에이전트)');
+    console.log('  open [agent_id]               - 브라우저에서 마인드맵 열기');
+    process.exit(1);
+  }
+
+  logUsage(command, agentId, rest.join(' '));
+
+  switch (command) {
+    case 'build':
+      if (!agentId) {
+        console.log('Error: agent_id is required');
+        process.exit(1);
+      }
+      cmdBuild(agentId, options);
+      break;
+
+    case 'show':
+      if (!agentId) {
+        console.log('Error: agent_id is required');
+        process.exit(1);
+      }
+      cmdShow(agentId);
+      break;
+
+    case 'related':
+      if (!agentId || !rest[0]) {
+        console.log('Error: agent_id and memory_id are required');
+        process.exit(1);
+      }
+      cmdRelated(agentId, rest[0]);
+      break;
+
+    case 'add':
+      if (!agentId || !rest[0] || !rest[1]) {
+        console.log('Error: agent_id, from_id and to_id are required');
+        process.exit(1);
+      }
+      cmdAdd(agentId, rest[0], rest[1], rest[2]);
+      break;
+
+    case 'remove':
+      if (!agentId || !rest[0] || !rest[1]) {
+        console.log('Error: agent_id, from_id and to_id are required');
+        process.exit(1);
+      }
+      cmdRemove(agentId, rest[0], rest[1]);
+      break;
+
+    case 'html':
+      cmdHtml();
+      break;
+
+    case 'open':
+      cmdOpen(agentId);
+      break;
+
+    default:
+      console.log(`Unknown command: ${command}`);
+      process.exit(1);
+  }
+}
+
+// CLI로 직접 실행할 때만 main() 호출
+if (require.main === module) {
+  main();
+}
+
+// 다른 모듈에서 import 가능하도록 export
+module.exports = { buildGraph };


### PR DESCRIPTION
## Summary
- Upgrade memory-v2 skill v0.4.1 → v0.7.0 (BM25 search, mindmap, skill-tracer)
- Add skills/lib/ shared library (bm25-search, mindmap, skill-tracer)
- Add `--output-format stream-json` to all 8 Claude agent options in crewx.yaml

## Changes

### memory-v2 Upgrade (v0.4.1 → v0.7.0)
- BM25 search algorithm with Korean/English language detection
- `created_at` ISO8601 timestamps
- Mindmap (memory connection graph) feature
- skill-tracer integration for execution tracing
- Semantic search provider changed: gemini → claude haiku

### skills/lib/ (New)
- `bm25-search.js` - BM25 text search engine
- `mindmap.js` - Memory graph visualization
- `skill-tracer.js` - Execution tracing utility
- `package.json` - Dependencies: better-sqlite3, wink-bm25-text-search, wink-nlp-utils, gray-matter

### Claude JSON Options
Added `--output-format stream-json` to query and execute options for all `cli/claude` agents:
- crewx_claude_dev, crewx_qa_lead, crewx_tester, crewx_release_manager
- crewx_dev_lead, sowonflow_claude_dev, gemini_cli_analyzer, mastra_analyzer

Non-Claude agents (gemini, codex, crush) were NOT modified.

Fixes #118