### PR TITLE
fix(#122): prevent EPIPE error in remote agent stdin handling

### DIFF
--- a/packages/sdk/src/core/providers/base-ai.provider.ts
+++ b/packages/sdk/src/core/providers/base-ai.provider.ts
@@ -862,17 +862,36 @@ Started: ${timestamp}
         // Send prompt via stdin if not in args
         const pipedContext = this.buildPipedContext(prompt, options);
 
-        if (pipedContext && this.shouldPipeContext(options)) {
-          child.stdin.write(pipedContext);
-          if (!pipedContext.endsWith('\n')) {
-            child.stdin.write('\n');
+        // Wrap stdin writes in error handling to prevent EPIPE
+        try {
+          if (pipedContext && this.shouldPipeContext(options)) {
+            child.stdin.write(pipedContext);
+            if (!pipedContext.endsWith('\n')) {
+              child.stdin.write('\n');
+            }
           }
-        }
 
-        if (!this.getPromptInArgs()) {
-          child.stdin.write(prompt);
+          if (!this.getPromptInArgs()) {
+            child.stdin.write(prompt);
+          }
+        } catch (stdinError: any) {
+          // Ignore EPIPE errors on stdin write (subprocess may not read stdin)
+          if (stdinError.code !== 'EPIPE') {
+            this.logger.warn(`stdin write error: ${stdinError.message}`);
+          }
+        } finally {
+          // Use setImmediate to ensure writes complete before ending stdin
+          setImmediate(() => {
+            try {
+              child.stdin.end();
+            } catch (endError: any) {
+              // Ignore errors on stdin.end() (subprocess may have already closed)
+              if (endError.code !== 'EPIPE') {
+                this.logger.warn(`stdin.end() error: ${endError.message}`);
+              }
+            }
+          });
         }
-        child.stdin.end();
 
         // Timeout handling
         const timeout = setTimeout(() => {
@@ -1148,17 +1167,36 @@ Started: ${timestamp}
         // Send prompt via stdin if not in args
         const pipedContext = this.buildPipedContext(prompt, options);
 
-        if (pipedContext && this.shouldPipeContext(options)) {
-          child.stdin.write(pipedContext);
-          if (!pipedContext.endsWith('\n')) {
-            child.stdin.write('\n');
+        // Wrap stdin writes in error handling to prevent EPIPE
+        try {
+          if (pipedContext && this.shouldPipeContext(options)) {
+            child.stdin.write(pipedContext);
+            if (!pipedContext.endsWith('\n')) {
+              child.stdin.write('\n');
+            }
           }
-        }
 
-        if (!this.getPromptInArgs()) {
-          child.stdin.write(prompt);
+          if (!this.getPromptInArgs()) {
+            child.stdin.write(prompt);
+          }
+        } catch (stdinError: any) {
+          // Ignore EPIPE errors on stdin write (subprocess may not read stdin)
+          if (stdinError.code !== 'EPIPE') {
+            this.logger.warn(`stdin write error: ${stdinError.message}`);
+          }
+        } finally {
+          // Use setImmediate to ensure writes complete before ending stdin
+          setImmediate(() => {
+            try {
+              child.stdin.end();
+            } catch (endError: any) {
+              // Ignore errors on stdin.end() (subprocess may have already closed)
+              if (endError.code !== 'EPIPE') {
+                this.logger.warn(`stdin.end() error: ${endError.message}`);
+              }
+            }
+          });
         }
-        child.stdin.end();
 
         // Timeout handling
         const timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
Fixes #122 - EPIPE error when using file:// remote agents

## Problem
- Remote agents using `file://` location throw EPIPE errors
- `child.stdin.end()` was called immediately after writes
- Subprocess may not be ready to read stdin, causing pipe break

## Solution
- Wrapped stdin writes in try-catch to handle EPIPE gracefully
- Used `setImmediate()` to ensure writes complete before closing stdin
- Applied to both `query()` and `execute()` methods in BaseAIProvider

## Changes
- `packages/sdk/src/core/providers/base-ai.provider.ts`: Enhanced stdin error handling

## Testing
- ✅ Build passed
- Ready for integration testing with remote agents

🤖 Generated with CrewX CLI