### PR TITLE
fix(#126): workspace middleware CJS/ESM-safe import pattern

### DIFF
--- a/packages/cli/src/middleware/workspace.middleware.ts
+++ b/packages/cli/src/middleware/workspace.middleware.ts
@@ -1,0 +1,75 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+/**
+ * Use default import to avoid CJS/ESM named-export crash.
+ * @sowonai/crewx-sdk ships as CommonJS; ESM named imports fail with:
+ *   "Named export 'hashWorkspaceId' not found"
+ * See: https://github.com/sowonlabs/crewx/issues/126
+ */
+import pkg from '@sowonai/crewx-sdk';
+const { hashWorkspaceId, normalizeWorkspacePath } = pkg;
+import * as path from 'path';
+
+export interface WorkspaceContext {
+  id: string;
+  path: string;
+  name: string;
+}
+
+declare module 'express' {
+  interface Request {
+    workspace?: WorkspaceContext;
+  }
+}
+
+/**
+ * Global middleware that resolves the current workspace from request headers
+ * and attaches a `WorkspaceContext` to every request.
+ *
+ * Resolution order:
+ * 1. `X-CrewX-Workspace` header (explicit workspace override)
+ * 2. `X-CrewX-Project` header (deprecated, backward compat)
+ * 3. `?project=` query param (deprecated, backward compat)
+ * 4. Server `process.cwd()` (boot-time cached default)
+ */
+@Injectable()
+export class WorkspaceMiddleware implements NestMiddleware {
+  private readonly defaultWorkspace: WorkspaceContext;
+
+  constructor() {
+    const cwd = process.cwd();
+    const normalized = normalizeWorkspacePath(cwd);
+    this.defaultWorkspace = {
+      id: hashWorkspaceId(cwd),
+      path: normalized,
+      name: path.basename(normalized),
+    };
+  }
+
+  use(req: Request, _res: Response, next: NextFunction): void {
+    const workspaceHeader = this.extractHeader(req, 'x-crewx-workspace');
+    const projectHeader = this.extractHeader(req, 'x-crewx-project');
+    const projectQuery = req.query['project'] as string | undefined;
+
+    const raw = workspaceHeader || projectHeader || projectQuery;
+
+    if (raw) {
+      const normalized = normalizeWorkspacePath(raw);
+      req.workspace = {
+        id: hashWorkspaceId(raw),
+        path: normalized,
+        name: path.basename(normalized),
+      };
+    } else {
+      req.workspace = this.defaultWorkspace;
+    }
+
+    next();
+  }
+
+  private extractHeader(req: Request, name: string): string | undefined {
+    const value = req.headers[name];
+    if (!value) return undefined;
+    return Array.isArray(value) ? value[0] : value;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -157,6 +157,9 @@ export type {
 } from './types/agent.types';
 export { ExecutionMode, SecurityLevel } from './types/agent.types';
 
+// Workspace utilities
+export { hashWorkspaceId, normalizeWorkspacePath } from './utils/workspace';
+
 // Shared utilities
 export { getErrorMessage, getErrorStack, isError } from './utils/error-utils';
 export {

--- a/packages/sdk/src/utils/workspace.ts
+++ b/packages/sdk/src/utils/workspace.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+/**
+ * Normalize a workspace directory path for consistent hashing.
+ *
+ * - Resolves to an absolute path via `path.resolve`
+ * - On Windows: converts backslashes to forward slashes and lowercases drive letter
+ * - Strips trailing slashes (except root paths like `/` or `C:/`)
+ *
+ * This normalization ensures the same physical directory always produces
+ * the same hash regardless of how the path was originally specified.
+ */
+export function normalizeWorkspacePath(workspacePath: string): string {
+  let resolved = path.resolve(workspacePath);
+
+  if (process.platform === 'win32') {
+    resolved = resolved.replace(/\\/g, '/');
+    resolved = resolved.replace(
+      /^([A-Z]):/,
+      (_match: string, drive: string) => `${drive.toLowerCase()}:`,
+    );
+  }
+
+  // Strip trailing slashes, but preserve root paths like "/" or "C:/"
+  if (resolved.length > 1 && !/^[a-zA-Z]:\/$/.test(resolved)) {
+    resolved = resolved.replace(/\/+$/, '');
+  }
+
+  return resolved;
+}
+
+/**
+ * Produce a SHA-256 hex digest (64 characters) that uniquely identifies a workspace
+ * by its normalized directory path.
+ *
+ * @param workspacePath - Directory path (will be normalized internally)
+ * @returns 64-character lowercase hex string (SHA-256)
+ */
+export function hashWorkspaceId(workspacePath: string): string {
+  const normalizedPath = normalizeWorkspacePath(workspacePath);
+  return createHash('sha256').update(normalizedPath).digest('hex');
+}


### PR DESCRIPTION
## Summary
- Add `hashWorkspaceId` and `normalizeWorkspacePath` utility functions to `@sowonai/crewx-sdk`
- Create `workspace.middleware.ts` using **default import pattern** (`import pkg from '@sowonai/crewx-sdk'`) to avoid Node.js CJS/ESM named export resolution crash
- Checked all other `@sowonai/crewx-sdk` imports in the CLI package — they are CJS context (`"type": "commonjs"`) and safe

## Root Cause
When `@sowonai/crewx-sdk` (CJS module) is imported via ESM named imports in an ESM context (e.g., `dist-server` with `"type": "module"`), Node.js throws:
```
SyntaxError: Named export 'hashWorkspaceId' not found
```

## Fix
Use default import + destructuring:
```ts
import pkg from '@sowonai/crewx-sdk';
const { hashWorkspaceId, normalizeWorkspacePath } = pkg;
```

Fixes #126

## Test plan
- [x] SDK builds successfully with new workspace utilities
- [x] CLI builds successfully with workspace middleware
- [x] SDK exports verified: `hashWorkspaceId` and `normalizeWorkspacePath` callable
- [x] Compiled output uses `__importDefault(require(...))` pattern
- [ ] Integration test in ESM context

🤖 Generated with [Claude Code](https://claude.com/claude-code)